### PR TITLE
EventBuilder

### DIFF
--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -1,6 +1,6 @@
 use super::SpecVersion;
 use crate::event::{AttributesV10, ExtensionValue};
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 
 /// Trait to get [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes).
 pub trait AttributesReader {
@@ -19,7 +19,7 @@ pub trait AttributesReader {
     /// Get the [subject](https://github.com/cloudevents/spec/blob/master/spec.md#subject).
     fn get_subject(&self) -> Option<&str>;
     /// Get the [time](https://github.com/cloudevents/spec/blob/master/spec.md#time).
-    fn get_time(&self) -> Option<&DateTime<FixedOffset>>;
+    fn get_time(&self) -> Option<&DateTime<Utc>>;
     /// Get the [extension](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes) named `extension_name`
     fn get_extension(&self, extension_name: &str) -> Option<&ExtensionValue>;
     /// Get all the [extensions](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
@@ -31,7 +31,7 @@ pub trait AttributesWriter {
     fn set_source(&mut self, source: impl Into<String>);
     fn set_type(&mut self, ty: impl Into<String>);
     fn set_subject(&mut self, subject: Option<impl Into<String>>);
-    fn set_time(&mut self, time: Option<impl Into<DateTime<FixedOffset>>>);
+    fn set_time(&mut self, time: Option<impl Into<DateTime<Utc>>>);
     fn set_extension<'name, 'event: 'name>(
         &'event mut self,
         extension_name: &'name str,
@@ -48,6 +48,7 @@ pub(crate) trait DataAttributesWriter {
     fn set_dataschema(&mut self, dataschema: Option<impl Into<String>>);
 }
 
+#[derive(PartialEq, Debug, Clone)]
 pub enum Attributes {
     V10(AttributesV10),
 }
@@ -95,7 +96,7 @@ impl AttributesReader for Attributes {
         }
     }
 
-    fn get_time(&self) -> Option<&DateTime<FixedOffset>> {
+    fn get_time(&self) -> Option<&DateTime<Utc>> {
         match self {
             Attributes::V10(a) => a.get_time(),
         }
@@ -139,7 +140,7 @@ impl AttributesWriter for Attributes {
         }
     }
 
-    fn set_time(&mut self, time: Option<impl Into<DateTime<FixedOffset>>>) {
+    fn set_time(&mut self, time: Option<impl Into<DateTime<Utc>>>) {
         match self {
             Attributes::V10(a) => a.set_time(time),
         }

--- a/src/event/builder.rs
+++ b/src/event/builder.rs
@@ -1,0 +1,21 @@
+use super::EventBuilderV10;
+
+/// Builder to create [`Event`]:
+/// ```
+/// use cloudevents::EventBuilder;
+/// use chrono::Utc;
+///
+/// let event = EventBuilder::v10()
+///     .id("my_event.my_application")
+///     .source("http://localhost:8080")
+///     .time(Utc::now())
+///     .build();
+/// ```
+pub struct EventBuilder {}
+
+impl EventBuilder {
+    /// Creates a new builder for CloudEvents V1.0
+    pub fn v10() -> EventBuilderV10 {
+        return EventBuilderV10::new()
+    }
+}

--- a/src/event/builder.rs
+++ b/src/event/builder.rs
@@ -16,6 +16,6 @@ pub struct EventBuilder {}
 impl EventBuilder {
     /// Creates a new builder for CloudEvents V1.0
     pub fn v10() -> EventBuilderV10 {
-        return EventBuilderV10::new()
+        return EventBuilderV10::new();
     }
 }

--- a/src/event/data.rs
+++ b/src/event/data.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::convert::{Into, TryFrom};
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 /// Possible data values
 pub enum Data {
     String(String),

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -117,7 +117,12 @@ impl Event {
     /// let mut e = Event::default();
     /// e.write_data_with_schema("application/json", "http://myapplication.com/schema", json!({}))
     /// ```
-    pub fn write_data_with_schema(&mut self, datacontenttype: impl Into<String>, dataschema: impl Into<String>, data: impl Into<Data>) {
+    pub fn write_data_with_schema(
+        &mut self,
+        datacontenttype: impl Into<String>,
+        dataschema: impl Into<String>,
+        data: impl Into<Data>,
+    ) {
         self.attributes.set_datacontenttype(Some(datacontenttype));
         self.attributes.set_dataschema(Some(dataschema));
         self.data = Some(data.into());
@@ -159,13 +164,12 @@ mod tests {
             "hello": "world"
         });
 
-         let mut e = Event::default();
-         e.write_data_with_schema(
-             "application/json",
-             "http://localhost:8080/schema",
-             expected_data.clone()
-         );
-
+        let mut e = Event::default();
+        e.write_data_with_schema(
+            "application/json",
+            "http://localhost:8080/schema",
+            expected_data.clone(),
+        );
 
         let data: serde_json::Value = e.try_get_data().unwrap().unwrap();
         assert_eq!(expected_data, data);
@@ -180,12 +184,14 @@ mod tests {
             "application/json",
             serde_json::json!({
                 "hello": "world"
-            })
+            }),
         );
 
         e.remove_data();
 
-        assert!(e.try_get_data::<serde_json::Value, serde_json::Error>().is_none());
+        assert!(e
+            .try_get_data::<serde_json::Value, serde_json::Error>()
+            .is_none());
         assert!(e.get_dataschema().is_none());
         assert!(e.get_datacontenttype().is_none());
     }

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -21,7 +21,6 @@ use std::convert::TryFrom;
 /// let mut e = Event::default();
 /// e.write_data(
 ///     "application/json",
-///     None,
 ///     serde_json::json!({"hello": "world"})
 /// );
 ///
@@ -92,7 +91,7 @@ impl Event {
         self.attributes.set_datacontenttype(None as Option<String>);
     }
 
-    /// Write data into the `Event`. You must provide a `content_type` and you can optionally provide a `schema`.
+    /// Write data into the `Event` with the specified `datacontenttype`.
     ///
     /// ```
     /// use cloudevents::Event;
@@ -100,12 +99,28 @@ impl Event {
     /// use std::convert::Into;
     ///
     /// let mut e = Event::default();
-    /// e.write_data("application/json", None, json!({}))
+    /// e.write_data("application/json", json!({}))
     /// ```
-    pub fn write_data(&mut self, content_type: impl Into<String>, schema: Option<impl Into<String>>, value: impl Into<Data>) {
-        self.attributes.set_datacontenttype(Some(content_type));
-        self.attributes.set_dataschema(schema);
-        self.data = Some(value.into());
+    pub fn write_data(&mut self, datacontenttype: impl Into<String>, data: impl Into<Data>) {
+        self.attributes.set_datacontenttype(Some(datacontenttype));
+        self.attributes.set_dataschema(None as Option<&str>);
+        self.data = Some(data.into());
+    }
+
+    /// Write data into the `Event` with the specified `datacontenttype` and `dataschema`.
+    ///
+    /// ```
+    /// use cloudevents::Event;
+    /// use serde_json::json;
+    /// use std::convert::Into;
+    ///
+    /// let mut e = Event::default();
+    /// e.write_data_with_schema("application/json", "http://myapplication.com/schema", json!({}))
+    /// ```
+    pub fn write_data_with_schema(&mut self, datacontenttype: impl Into<String>, dataschema: impl Into<String>, data: impl Into<Data>) {
+        self.attributes.set_datacontenttype(Some(datacontenttype));
+        self.attributes.set_dataschema(Some(dataschema));
+        self.data = Some(data.into());
     }
 
     pub fn get_data<T: Sized + From<Data>>(&self) -> Option<T> {
@@ -145,9 +160,9 @@ mod tests {
         });
 
          let mut e = Event::default();
-         e.write_data(
+         e.write_data_with_schema(
              "application/json",
-             Some("http://localhost:8080/schema"),
+             "http://localhost:8080/schema",
              expected_data.clone()
          );
 
@@ -163,7 +178,6 @@ mod tests {
         let mut e = Event::default();
         e.write_data(
             "application/json",
-            None as Option<String>,
             serde_json::json!({
                 "hello": "world"
             })

--- a/src/event/extensions.rs
+++ b/src/event/extensions.rs
@@ -1,9 +1,7 @@
-use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::convert::From;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
-#[serde(untagged)]
+#[derive(Debug, PartialEq, Clone)]
 /// Represents all the possible [CloudEvents extension](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes) values
 pub enum ExtensionValue {
     /// Represents a [`String`](std::string::String) value.

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -3,6 +3,7 @@ mod data;
 mod event;
 mod extensions;
 mod spec_version;
+mod builder;
 
 pub use attributes::Attributes;
 pub use attributes::{AttributesReader, AttributesWriter};
@@ -10,7 +11,9 @@ pub use data::Data;
 pub use event::Event;
 pub use extensions::ExtensionValue;
 pub use spec_version::SpecVersion;
+pub use builder::EventBuilder;
 
 mod v10;
 
 pub use v10::Attributes as AttributesV10;
+pub use v10::EventBuilder as EventBuilderV10;

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,17 +1,17 @@
 mod attributes;
+mod builder;
 mod data;
 mod event;
 mod extensions;
 mod spec_version;
-mod builder;
 
 pub use attributes::Attributes;
 pub use attributes::{AttributesReader, AttributesWriter};
+pub use builder::EventBuilder;
 pub use data::Data;
 pub use event::Event;
 pub use extensions::ExtensionValue;
 pub use spec_version::SpecVersion;
-pub use builder::EventBuilder;
 
 mod v10;
 

--- a/src/event/v10/attributes.rs
+++ b/src/event/v10/attributes.rs
@@ -1,10 +1,11 @@
 use crate::event::attributes::DataAttributesWriter;
 use crate::event::{AttributesReader, AttributesWriter, ExtensionValue, SpecVersion};
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 use hostname::get_hostname;
 use std::collections::HashMap;
 use uuid::Uuid;
 
+#[derive(PartialEq, Debug, Clone)]
 pub struct Attributes {
     id: String,
     ty: String,
@@ -12,7 +13,7 @@ pub struct Attributes {
     datacontenttype: Option<String>,
     dataschema: Option<String>,
     subject: Option<String>,
-    time: Option<DateTime<FixedOffset>>,
+    time: Option<DateTime<Utc>>,
     extensions: HashMap<String, ExtensionValue>,
 }
 
@@ -54,7 +55,7 @@ impl AttributesReader for Attributes {
         }
     }
 
-    fn get_time(&self) -> Option<&DateTime<FixedOffset>> {
+    fn get_time(&self) -> Option<&DateTime<Utc>> {
         self.time.as_ref()
     }
 
@@ -87,7 +88,7 @@ impl AttributesWriter for Attributes {
         self.subject = subject.map(Into::into)
     }
 
-    fn set_time(&mut self, time: Option<impl Into<DateTime<FixedOffset>>>) {
+    fn set_time(&mut self, time: Option<impl Into<DateTime<Utc>>>) {
         self.time = time.map(Into::into)
     }
 

--- a/src/event/v10/builder.rs
+++ b/src/event/v10/builder.rs
@@ -1,0 +1,110 @@
+use crate::event::{Event, Data, Attributes, AttributesWriter, ExtensionValue};
+use super::Attributes as AttributesV10;
+use chrono::{Utc, DateTime};
+
+pub struct EventBuilder {
+    event: Event
+}
+
+impl EventBuilder {
+
+    // This works as soon as we have an event version converter
+    // pub fn from(event: Event) -> Self {
+    //     EventBuilder { event }
+    // }
+
+    pub fn new() -> Self {
+        EventBuilder {
+            event: Event {
+                attributes: Attributes::V10(AttributesV10::default()),
+                data: None
+            }
+        }
+    }
+
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.event.set_id(id);
+        return self
+    }
+
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.event.set_source(source);
+        return self
+    }
+
+    pub fn ty(mut self, ty: impl Into<String>) -> Self {
+        self.event.set_type(ty);
+        return self
+    }
+
+    pub fn subject(mut self, subject: impl Into<String>) -> Self {
+        self.event.set_subject(Some(subject));
+        return self
+    }
+
+    pub fn time(mut self, time: impl Into<DateTime<Utc>>) -> Self {
+        self.event.set_time(Some(time));
+        return self
+    }
+
+    pub fn extension(mut self, extension_name: &str, extension_value: impl Into<ExtensionValue>) -> Self {
+        self.event.set_extension(extension_name, extension_value);
+        return self
+    }
+
+    pub fn data<S: Into<String>, D: Into<Data>>(mut self, content_type: S, schema: Option<S>, value: D) -> Self {
+        self.event.write_data(content_type, schema, value);
+        return self
+    }
+
+    pub fn build(self) -> Event {
+        self.event
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{AttributesReader, SpecVersion};
+
+    #[test]
+    fn build_event() {
+        let id = "aaa";
+        let source = "http://localhost:8080";
+        let ty = "bbb";
+        let subject = "francesco";
+        let time: DateTime<Utc> = Utc::now();
+        let extension_name = "ext";
+        let extension_value = 10i64;
+        let content_type = "application/json";
+        let schema = "http://localhost:8080/schema";
+        let data = serde_json::json!({
+            "hello": "world"
+        });
+
+        let event = EventBuilder::new()
+            .id(id)
+            .source(source)
+            .ty(ty)
+            .subject(subject)
+            .time(time)
+            .extension(extension_name, extension_value)
+            .data(content_type, Some(schema), data.clone())
+            .build();
+
+        assert_eq!(SpecVersion::V10, event.get_specversion());
+        assert_eq!(id, event.get_id());
+        assert_eq!(source, event.get_source());
+        assert_eq!(ty, event.get_type());
+        assert_eq!(subject, event.get_subject().unwrap());
+        assert_eq!(time, event.get_time().unwrap().clone());
+        assert_eq!(ExtensionValue::from(extension_value), event.get_extension(extension_name).unwrap().clone());
+        assert_eq!(content_type, event.get_datacontenttype().unwrap());
+        assert_eq!(schema, event.get_dataschema().unwrap());
+
+        let event_data: serde_json::Value = event.try_get_data().unwrap().unwrap();
+        assert_eq!(data, event_data);
+    }
+
+}

--- a/src/event/v10/builder.rs
+++ b/src/event/v10/builder.rs
@@ -1,13 +1,12 @@
-use crate::event::{Event, Data, Attributes, AttributesWriter, ExtensionValue};
 use super::Attributes as AttributesV10;
-use chrono::{Utc, DateTime};
+use crate::event::{Attributes, AttributesWriter, Data, Event, ExtensionValue};
+use chrono::{DateTime, Utc};
 
 pub struct EventBuilder {
-    event: Event
+    event: Event,
 }
 
 impl EventBuilder {
-
     // This works as soon as we have an event version converter
     // pub fn from(event: Event) -> Self {
     //     EventBuilder { event }
@@ -17,55 +16,64 @@ impl EventBuilder {
         EventBuilder {
             event: Event {
                 attributes: Attributes::V10(AttributesV10::default()),
-                data: None
-            }
+                data: None,
+            },
         }
     }
 
     pub fn id(mut self, id: impl Into<String>) -> Self {
         self.event.set_id(id);
-        return self
+        return self;
     }
 
     pub fn source(mut self, source: impl Into<String>) -> Self {
         self.event.set_source(source);
-        return self
+        return self;
     }
 
     pub fn ty(mut self, ty: impl Into<String>) -> Self {
         self.event.set_type(ty);
-        return self
+        return self;
     }
 
     pub fn subject(mut self, subject: impl Into<String>) -> Self {
         self.event.set_subject(Some(subject));
-        return self
+        return self;
     }
 
     pub fn time(mut self, time: impl Into<DateTime<Utc>>) -> Self {
         self.event.set_time(Some(time));
-        return self
+        return self;
     }
 
-    pub fn extension(mut self, extension_name: &str, extension_value: impl Into<ExtensionValue>) -> Self {
+    pub fn extension(
+        mut self,
+        extension_name: &str,
+        extension_value: impl Into<ExtensionValue>,
+    ) -> Self {
         self.event.set_extension(extension_name, extension_value);
-        return self
+        return self;
     }
 
     pub fn data(mut self, datacontenttype: impl Into<String>, data: impl Into<Data>) -> Self {
         self.event.write_data(datacontenttype, data);
-        return self
+        return self;
     }
 
-    pub fn data_with_schema(mut self, datacontenttype: impl Into<String>, dataschema: impl Into<String>, data: impl Into<Data>) -> Self {
-        self.event.write_data_with_schema(datacontenttype, dataschema, data);
-        return self
+    pub fn data_with_schema(
+        mut self,
+        datacontenttype: impl Into<String>,
+        dataschema: impl Into<String>,
+        data: impl Into<Data>,
+    ) -> Self {
+        self.event
+            .write_data_with_schema(datacontenttype, dataschema, data);
+        return self;
     }
 
     pub fn build(self) -> Event {
         self.event
     }
-
 }
 
 #[cfg(test)]
@@ -104,12 +112,14 @@ mod tests {
         assert_eq!(ty, event.get_type());
         assert_eq!(subject, event.get_subject().unwrap());
         assert_eq!(time, event.get_time().unwrap().clone());
-        assert_eq!(ExtensionValue::from(extension_value), event.get_extension(extension_name).unwrap().clone());
+        assert_eq!(
+            ExtensionValue::from(extension_value),
+            event.get_extension(extension_name).unwrap().clone()
+        );
         assert_eq!(content_type, event.get_datacontenttype().unwrap());
         assert_eq!(schema, event.get_dataschema().unwrap());
 
         let event_data: serde_json::Value = event.try_get_data().unwrap().unwrap();
         assert_eq!(data, event_data);
     }
-
 }

--- a/src/event/v10/builder.rs
+++ b/src/event/v10/builder.rs
@@ -52,8 +52,13 @@ impl EventBuilder {
         return self
     }
 
-    pub fn data<S: Into<String>, D: Into<Data>>(mut self, content_type: S, schema: Option<S>, value: D) -> Self {
-        self.event.write_data(content_type, schema, value);
+    pub fn data(mut self, datacontenttype: impl Into<String>, data: impl Into<Data>) -> Self {
+        self.event.write_data(datacontenttype, data);
+        return self
+    }
+
+    pub fn data_with_schema(mut self, datacontenttype: impl Into<String>, dataschema: impl Into<String>, data: impl Into<Data>) -> Self {
+        self.event.write_data_with_schema(datacontenttype, dataschema, data);
         return self
     }
 
@@ -90,7 +95,7 @@ mod tests {
             .subject(subject)
             .time(time)
             .extension(extension_name, extension_value)
-            .data(content_type, Some(schema), data.clone())
+            .data_with_schema(content_type, schema, data.clone())
             .build();
 
         assert_eq!(SpecVersion::V10, event.get_specversion());

--- a/src/event/v10/mod.rs
+++ b/src/event/v10/mod.rs
@@ -1,3 +1,5 @@
 mod attributes;
+mod builder;
 
 pub use attributes::Attributes;
+pub use builder::EventBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ extern crate serde_json;
 pub mod event;
 
 pub use event::Event;
+pub use event::EventBuilder;


### PR DESCRIPTION
Created an event builder to improve usability of the `Event` data structure:

```rust
use cloudevents::EventBuilder;
use chrono::Utc;

let event = EventBuilder::v10()
     .id("my_event.my_application")
     .source("http://localhost:8080")
     .time(Utc::now())
     .build();
```

Fixes #13 

Also now all DateTimes used are Utc (spec wants that conversion back/forth of datetimes are without timezone, so it's reasonable to impose always UTC)

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>