### PR TITLE
Disabled dead code warning in test data

### DIFF
--- a/tests/test_data/mod.rs
+++ b/tests/test_data/mod.rs
@@ -1,5 +1,8 @@
+#[allow(dead_code)]
 mod data;
 pub use data::*;
 
+#[allow(dead_code)]
 pub mod v03;
+#[allow(dead_code)]
 pub mod v10;


### PR DESCRIPTION
This disables dead code warning on test data (which probably appears because of rstest macro)

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>