### PR TITLE
Removed cloudevents::event::SPEC_VERSION_ATTRIBUTES

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ exclude = [
     ".github/*"
 ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "cloudevents"
 
 [dependencies]
 serde = { version = "^1.0", features = ["derive"] }
@@ -23,7 +24,6 @@ delegate = "^0.4"
 base64 = "^0.12"
 url = { version = "^2.1", features = ["serde"] }
 snafu = "^0.6"
-lazy_static = "1.4.0"
 
 [target."cfg(not(target_arch = \"wasm32\"))".dependencies]
 hostname = "^0.3"
@@ -36,9 +36,6 @@ uuid = { version = "^0.8", features = ["v4", "wasm-bindgen"] }
 [dev-dependencies]
 rstest = "0.6"
 claim = "0.3.1"
-
-[lib]
-name = "cloudevents"
 
 [workspace]
 members = [

--- a/cloudevents-sdk-actix-web/src/headers.rs
+++ b/cloudevents-sdk-actix-web/src/headers.rs
@@ -46,15 +46,14 @@ macro_rules! attribute_name_to_header {
 }
 
 fn attributes_to_headers(
-    map: &HashMap<SpecVersion, &'static [&'static str]>,
+    it: impl Iterator<Item=&'static str>,
 ) -> HashMap<&'static str, HeaderName> {
-    map.values()
-        .flat_map(|s| s.iter())
+    it
         .map(|s| {
-            if *s == "datacontenttype" {
-                (*s, header::CONTENT_TYPE)
+            if s == "datacontenttype" {
+                (s, header::CONTENT_TYPE)
             } else {
-                (*s, attribute_name_to_header!(s).unwrap())
+                (s, attribute_name_to_header!(s).unwrap())
             }
         })
         .collect()
@@ -62,7 +61,7 @@ fn attributes_to_headers(
 
 lazy_static! {
     pub(crate) static ref ATTRIBUTES_TO_HEADERS: HashMap<&'static str, HeaderName> =
-        attributes_to_headers(&cloudevents::event::SPEC_VERSION_ATTRIBUTES);
+        attributes_to_headers(SpecVersion::all_attribute_names());
     pub(crate) static ref SPEC_VERSION_HEADER: HeaderName =
         HeaderName::from_static("ce-specversion");
     pub(crate) static ref CLOUDEVENTS_JSON_HEADER: HeaderValue =

--- a/cloudevents-sdk-actix-web/src/headers.rs
+++ b/cloudevents-sdk-actix-web/src/headers.rs
@@ -46,17 +46,16 @@ macro_rules! attribute_name_to_header {
 }
 
 fn attributes_to_headers(
-    it: impl Iterator<Item=&'static str>,
+    it: impl Iterator<Item = &'static str>,
 ) -> HashMap<&'static str, HeaderName> {
-    it
-        .map(|s| {
-            if s == "datacontenttype" {
-                (s, header::CONTENT_TYPE)
-            } else {
-                (s, attribute_name_to_header!(s).unwrap())
-            }
-        })
-        .collect()
+    it.map(|s| {
+        if s == "datacontenttype" {
+            (s, header::CONTENT_TYPE)
+        } else {
+            (s, attribute_name_to_header!(s).unwrap())
+        }
+    })
+    .collect()
 }
 
 lazy_static! {

--- a/cloudevents-sdk-actix-web/src/server_request.rs
+++ b/cloudevents-sdk-actix-web/src/server_request.rs
@@ -35,9 +35,7 @@ impl<'a> BinaryDeserializer for HttpRequestDeserializer<'a> {
 
         visitor = visitor.set_spec_version(spec_version.clone())?;
 
-        let attributes = cloudevents::event::SPEC_VERSION_ATTRIBUTES
-            .get(&spec_version)
-            .unwrap();
+        let attributes = spec_version.attribute_names();
 
         for (hn, hv) in
             self.req.headers().iter().filter(|(hn, _)| {

--- a/cloudevents-sdk-reqwest/src/client_response.rs
+++ b/cloudevents-sdk-reqwest/src/client_response.rs
@@ -34,9 +34,7 @@ impl BinaryDeserializer for ResponseDeserializer {
 
         visitor = visitor.set_spec_version(spec_version.clone())?;
 
-        let attributes = cloudevents::event::SPEC_VERSION_ATTRIBUTES
-            .get(&spec_version)
-            .unwrap();
+        let attributes = spec_version.attribute_names();
 
         for (hn, hv) in self
             .headers

--- a/cloudevents-sdk-reqwest/src/headers.rs
+++ b/cloudevents-sdk-reqwest/src/headers.rs
@@ -39,15 +39,14 @@ macro_rules! attribute_name_to_header {
 }
 
 fn attributes_to_headers(
-    map: &HashMap<SpecVersion, &'static [&'static str]>,
+    it: impl Iterator<Item=&'static str>,
 ) -> HashMap<&'static str, HeaderName> {
-    map.values()
-        .flat_map(|s| s.iter())
+    it
         .map(|s| {
-            if *s == "datacontenttype" {
-                (*s, reqwest::header::CONTENT_TYPE)
+            if s == "datacontenttype" {
+                (s, reqwest::header::CONTENT_TYPE)
             } else {
-                (*s, attribute_name_to_header!(s).unwrap())
+                (s, attribute_name_to_header!(s).unwrap())
             }
         })
         .collect()
@@ -55,7 +54,7 @@ fn attributes_to_headers(
 
 lazy_static! {
     pub(crate) static ref ATTRIBUTES_TO_HEADERS: HashMap<&'static str, HeaderName> =
-        attributes_to_headers(&cloudevents::event::SPEC_VERSION_ATTRIBUTES);
+        attributes_to_headers(SpecVersion::all_attribute_names());
     pub(crate) static ref SPEC_VERSION_HEADER: HeaderName =
         HeaderName::from_static("ce-specversion");
     pub(crate) static ref CLOUDEVENTS_JSON_HEADER: HeaderValue =

--- a/cloudevents-sdk-reqwest/src/headers.rs
+++ b/cloudevents-sdk-reqwest/src/headers.rs
@@ -39,17 +39,16 @@ macro_rules! attribute_name_to_header {
 }
 
 fn attributes_to_headers(
-    it: impl Iterator<Item=&'static str>,
+    it: impl Iterator<Item = &'static str>,
 ) -> HashMap<&'static str, HeaderName> {
-    it
-        .map(|s| {
-            if s == "datacontenttype" {
-                (s, reqwest::header::CONTENT_TYPE)
-            } else {
-                (s, attribute_name_to_header!(s).unwrap())
-            }
-        })
-        .collect()
+    it.map(|s| {
+        if s == "datacontenttype" {
+            (s, reqwest::header::CONTENT_TYPE)
+        } else {
+            (s, attribute_name_to_header!(s).unwrap())
+        }
+    })
+    .collect()
 }
 
 lazy_static! {

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -16,7 +16,6 @@ pub use event::Event;
 pub use extensions::ExtensionValue;
 pub use spec_version::InvalidSpecVersion;
 pub use spec_version::SpecVersion;
-pub use spec_version::ATTRIBUTE_NAMES as SPEC_VERSION_ATTRIBUTES;
 
 mod v03;
 

--- a/src/event/spec_version.rs
+++ b/src/event/spec_version.rs
@@ -25,12 +25,12 @@ impl SpecVersion {
     pub fn attribute_names(&self) -> &'static [&'static str] {
         match self {
             SpecVersion::V03 => &v03::ATTRIBUTE_NAMES,
-            SpecVersion::V10 => &v10::ATTRIBUTE_NAMES
+            SpecVersion::V10 => &v10::ATTRIBUTE_NAMES,
         }
     }
     /// Get all attribute names for all Spec versions.
     /// Note that the result iterator could contain duplicate entries.
-    pub fn all_attribute_names() -> impl Iterator<Item=&'static str> {
+    pub fn all_attribute_names() -> impl Iterator<Item = &'static str> {
         vec![SpecVersion::V03, SpecVersion::V10]
             .into_iter()
             .flat_map(|s| s.attribute_names().to_owned().into_iter())

--- a/src/event/spec_version.rs
+++ b/src/event/spec_version.rs
@@ -1,19 +1,7 @@
 use super::{v03, v10};
-use lazy_static::lazy_static;
 use serde::export::Formatter;
-use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
-
-lazy_static! {
-    /// Lazily initialized map that contains all the context attribute names per [`SpecVersion`]
-    pub static ref ATTRIBUTE_NAMES: HashMap<SpecVersion, &'static [&'static str]> = {
-        let mut m = HashMap::new();
-        m.insert(SpecVersion::V03, &v03::ATTRIBUTE_NAMES[..]);
-        m.insert(SpecVersion::V10, &v10::ATTRIBUTE_NAMES[..]);
-        m
-    };
-}
 
 pub(crate) const SPEC_VERSIONS: [&'static str; 2] = ["0.3", "1.0"];
 
@@ -30,6 +18,22 @@ impl SpecVersion {
             SpecVersion::V03 => "0.3",
             SpecVersion::V10 => "1.0",
         }
+    }
+
+    /// Get all attribute names for this [`SpecVersion`].
+    #[inline]
+    pub fn attribute_names(&self) -> &'static [&'static str] {
+        match self {
+            SpecVersion::V03 => &v03::ATTRIBUTE_NAMES,
+            SpecVersion::V10 => &v10::ATTRIBUTE_NAMES
+        }
+    }
+    /// Get all attribute names for all Spec versions.
+    /// Note that the result iterator could contain duplicate entries.
+    pub fn all_attribute_names() -> impl Iterator<Item=&'static str> {
+        vec![SpecVersion::V03, SpecVersion::V10]
+            .into_iter()
+            .flat_map(|s| s.attribute_names().to_owned().into_iter())
     }
 }
 


### PR DESCRIPTION
Replaced with methods on `SpecVersion`

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>