### PR TITLE
Refactored iterator methods of Event

### DIFF
--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -1,10 +1,11 @@
 use super::{
-    AttributesIntoIteratorV03, AttributesIntoIteratorV10, AttributesV03, AttributesV10, SpecVersion, ExtensionValue
+    AttributesIntoIteratorV03, AttributesIntoIteratorV10, AttributesV03, AttributesV10,
+    ExtensionValue, SpecVersion,
 };
 use chrono::{DateTime, Utc};
+use serde::Serializer;
 use std::fmt;
 use url::Url;
-use serde::Serializer;
 
 /// Value of a CloudEvent attribute
 #[derive(Debug, PartialEq)]
@@ -18,12 +19,12 @@ pub enum AttributeValue<'a> {
     Time(&'a DateTime<Utc>),
 }
 
-impl <'a> From<&'a ExtensionValue> for AttributeValue<'a> {
+impl<'a> From<&'a ExtensionValue> for AttributeValue<'a> {
     fn from(ev: &'a ExtensionValue) -> Self {
         match ev {
             ExtensionValue::String(s) => AttributeValue::String(s),
             ExtensionValue::Boolean(b) => AttributeValue::Boolean(b),
-            ExtensionValue::Integer(i) => AttributeValue::Integer(i)
+            ExtensionValue::Integer(i) => AttributeValue::Integer(i),
         }
     }
 }

--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -1,17 +1,31 @@
 use super::{
-    AttributesIntoIteratorV03, AttributesIntoIteratorV10, AttributesV03, AttributesV10, SpecVersion,
+    AttributesIntoIteratorV03, AttributesIntoIteratorV10, AttributesV03, AttributesV10, SpecVersion, ExtensionValue
 };
 use chrono::{DateTime, Utc};
 use std::fmt;
 use url::Url;
+use serde::Serializer;
 
+/// Value of a CloudEvent attribute
 #[derive(Debug, PartialEq)]
 pub enum AttributeValue<'a> {
     SpecVersion(SpecVersion),
     String(&'a str),
     URI(&'a Url),
     URIRef(&'a Url),
+    Boolean(&'a bool),
+    Integer(&'a i64),
     Time(&'a DateTime<Utc>),
+}
+
+impl <'a> From<&'a ExtensionValue> for AttributeValue<'a> {
+    fn from(ev: &'a ExtensionValue) -> Self {
+        match ev {
+            ExtensionValue::String(s) => AttributeValue::String(s),
+            ExtensionValue::Boolean(b) => AttributeValue::Boolean(b),
+            ExtensionValue::Integer(i) => AttributeValue::Integer(i)
+        }
+    }
 }
 
 impl fmt::Display for AttributeValue<'_> {
@@ -22,6 +36,8 @@ impl fmt::Display for AttributeValue<'_> {
             AttributeValue::URI(s) => f.write_str(&s.as_str()),
             AttributeValue::URIRef(s) => f.write_str(&s.as_str()),
             AttributeValue::Time(s) => f.write_str(&s.to_rfc3339()),
+            AttributeValue::Boolean(b) => f.serialize_bool(**b),
+            AttributeValue::Integer(i) => f.serialize_i64(**i),
         }
     }
 }

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -80,17 +80,14 @@ impl Default for Event {
 impl Event {
     /// Returns an [`Iterator`] for all the available [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes) and extensions.
     /// Same as chaining [`Event::iter_attributes()`] and [`Event::iter_extensions()`]
-    pub fn iter(&self) -> impl Iterator<Item=(&str, AttributeValue)> {
-        self.iter_attributes().chain(
-            self.extensions
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.into()))
-        )
+    pub fn iter(&self) -> impl Iterator<Item = (&str, AttributeValue)> {
+        self.iter_attributes()
+            .chain(self.extensions.iter().map(|(k, v)| (k.as_str(), v.into())))
     }
 
     /// Returns an [`Iterator`] for all the available [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes), excluding extensions.
     /// This iterator does not contain the `data` field.
-    pub fn iter_attributes(&self) -> impl Iterator<Item=(&str, AttributeValue)> {
+    pub fn iter_attributes(&self) -> impl Iterator<Item = (&str, AttributeValue)> {
         match &self.attributes {
             Attributes::V03(a) => AttributesIter::IterV03(a.into_iter()),
             Attributes::V10(a) => AttributesIter::IterV10(a.into_iter()),
@@ -98,10 +95,8 @@ impl Event {
     }
 
     /// Get all the [extensions](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
-    pub fn iter_extensions(&self) -> impl Iterator<Item=(&str, &ExtensionValue)> {
-        self.extensions
-            .iter()
-            .map(|(k, v)| (k.as_str(), v))
+    pub fn iter_extensions(&self) -> impl Iterator<Item = (&str, &ExtensionValue)> {
+        self.extensions.iter().map(|(k, v)| (k.as_str(), v))
     }
 
     /// Remove `data`, `dataschema` and `datacontenttype` from this `Event`
@@ -259,7 +254,10 @@ mod tests {
 
         let mut v: HashMap<&str, AttributeValue> = e.iter().collect();
 
-        assert_eq!(v.remove("specversion"), Some(AttributeValue::SpecVersion(SpecVersion::V10)));
+        assert_eq!(
+            v.remove("specversion"),
+            Some(AttributeValue::SpecVersion(SpecVersion::V10))
+        );
         assert_eq!(v.remove("aaa"), Some(AttributeValue::String("bbb")))
     }
 }

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -78,12 +78,30 @@ impl Default for Event {
 }
 
 impl Event {
-    /// Returns an [`Iterator`] for [`Attributes`]
-    pub fn attributes_iter<'a>(&'a self) -> impl Iterator<Item = (&'a str, AttributeValue<'a>)> {
+    /// Returns an [`Iterator`] for all the available [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes) and extensions.
+    /// Same as chaining [`Event::iter_attributes()`] and [`Event::iter_extensions()`]
+    pub fn iter(&self) -> impl Iterator<Item=(&str, AttributeValue)> {
+        self.iter_attributes().chain(
+            self.extensions
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.into()))
+        )
+    }
+
+    /// Returns an [`Iterator`] for all the available [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes), excluding extensions.
+    /// This iterator does not contain the `data` field.
+    pub fn iter_attributes(&self) -> impl Iterator<Item=(&str, AttributeValue)> {
         match &self.attributes {
             Attributes::V03(a) => AttributesIter::IterV03(a.into_iter()),
             Attributes::V10(a) => AttributesIter::IterV10(a.into_iter()),
         }
+    }
+
+    /// Get all the [extensions](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
+    pub fn iter_extensions(&self) -> impl Iterator<Item=(&str, &ExtensionValue)> {
+        self.extensions
+            .iter()
+            .map(|(k, v)| (k.as_str(), v))
     }
 
     /// Remove `data`, `dataschema` and `datacontenttype` from this `Event`
@@ -166,14 +184,6 @@ impl Event {
         self.extensions.get(extension_name)
     }
 
-    /// Get all the [extensions](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes)
-    pub fn get_extensions(&self) -> Vec<(&str, &ExtensionValue)> {
-        self.extensions
-            .iter()
-            .map(|(k, v)| (k.as_str(), v))
-            .collect()
-    }
-
     /// Set the [extension](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes) named `extension_name` with `extension_value`
     pub fn set_extension<'name, 'event: 'name>(
         &'event mut self,
@@ -234,5 +244,22 @@ mod tests {
         assert!(e.try_get_data::<serde_json::Value>().unwrap().is_none());
         assert!(e.get_dataschema().is_none());
         assert!(e.get_datacontenttype().is_none());
+    }
+
+    #[test]
+    fn iter() {
+        let mut e = Event::default();
+        e.set_extension("aaa", "bbb");
+        e.write_data(
+            "application/json",
+            serde_json::json!({
+                "hello": "world"
+            }),
+        );
+
+        let mut v: HashMap<&str, AttributeValue> = e.iter().collect();
+
+        assert_eq!(v.remove("specversion"), Some(AttributeValue::SpecVersion(SpecVersion::V10)));
+        assert_eq!(v.remove("aaa"), Some(AttributeValue::String("bbb")))
     }
 }

--- a/tests/attributes_iter.rs
+++ b/tests/attributes_iter.rs
@@ -6,7 +6,7 @@ use test_data::*;
 #[test]
 fn iter_v10_test() {
     let in_event = v10::full_no_data();
-    let mut iter_v10 = in_event.attributes_iter();
+    let mut iter_v10 = in_event.iter_attributes();
 
     assert_eq!(
         ("specversion", AttributeValue::SpecVersion(SpecVersion::V10)),
@@ -17,7 +17,7 @@ fn iter_v10_test() {
 #[test]
 fn iter_v03_test() {
     let in_event = v03::full_json_data();
-    let mut iter_v03 = in_event.attributes_iter();
+    let mut iter_v03 = in_event.iter_attributes();
 
     assert_eq!(
         ("specversion", AttributeValue::SpecVersion(SpecVersion::V03)),


### PR DESCRIPTION
This PR aligns the different iterator APIs entrypoint of `Event` and adds a new method `Event::iter()` that returns the chained iterators of attributes and extensions

Fix #63

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>