### PR TITLE
bump actix web dependency to v3

### DIFF
--- a/cloudevents-sdk-actix-web/Cargo.toml
+++ b/cloudevents-sdk-actix-web/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 cloudevents-sdk = { version = "0.2.0", path = ".." }
-actix-web = "2"
+actix-web = { version = "3.0.2", default-features = false }
 actix-rt = "1"
 async-trait = "^0.1.33"
 lazy_static = "1.4.0"


### PR DESCRIPTION
do not include default features for actix-web

Note: I've just been doing a sweep of actix-web libs to inform of this default feature thing so I haven't dug into this repo at all. It's possible that the v3 upgrade won't just work but it's also possible that a dependency of `2, <4` would also work for you without being a breaking change to this lib.

closes #82