### PR TITLE
Cleanup to follow C-GETTER

### DIFF
--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -46,21 +46,21 @@ impl fmt::Display for AttributeValue<'_> {
 /// Trait to get [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes).
 pub trait AttributesReader {
     /// Get the [id](https://github.com/cloudevents/spec/blob/master/spec.md#id).
-    fn get_id(&self) -> &str;
+    fn id(&self) -> &str;
     /// Get the [source](https://github.com/cloudevents/spec/blob/master/spec.md#source-1).
-    fn get_source(&self) -> &Url;
+    fn source(&self) -> &Url;
     /// Get the [specversion](https://github.com/cloudevents/spec/blob/master/spec.md#specversion).
-    fn get_specversion(&self) -> SpecVersion;
+    fn specversion(&self) -> SpecVersion;
     /// Get the [type](https://github.com/cloudevents/spec/blob/master/spec.md#type).
-    fn get_type(&self) -> &str;
+    fn ty(&self) -> &str;
     /// Get the [datacontenttype](https://github.com/cloudevents/spec/blob/master/spec.md#datacontenttype).
-    fn get_datacontenttype(&self) -> Option<&str>;
+    fn datacontenttype(&self) -> Option<&str>;
     /// Get the [dataschema](https://github.com/cloudevents/spec/blob/master/spec.md#dataschema).
-    fn get_dataschema(&self) -> Option<&Url>;
+    fn dataschema(&self) -> Option<&Url>;
     /// Get the [subject](https://github.com/cloudevents/spec/blob/master/spec.md#subject).
-    fn get_subject(&self) -> Option<&str>;
+    fn subject(&self) -> Option<&str>;
     /// Get the [time](https://github.com/cloudevents/spec/blob/master/spec.md#time).
-    fn get_time(&self) -> Option<&DateTime<Utc>>;
+    fn time(&self) -> Option<&DateTime<Utc>>;
 }
 
 /// Trait to set [CloudEvents Context attributes](https://github.com/cloudevents/spec/blob/master/spec.md#context-attributes).
@@ -117,59 +117,59 @@ pub enum Attributes {
 }
 
 impl AttributesReader for Attributes {
-    fn get_id(&self) -> &str {
+    fn id(&self) -> &str {
         match self {
-            Attributes::V03(a) => a.get_id(),
-            Attributes::V10(a) => a.get_id(),
+            Attributes::V03(a) => a.id(),
+            Attributes::V10(a) => a.id(),
         }
     }
 
-    fn get_source(&self) -> &Url {
+    fn source(&self) -> &Url {
         match self {
-            Attributes::V03(a) => a.get_source(),
-            Attributes::V10(a) => a.get_source(),
+            Attributes::V03(a) => a.source(),
+            Attributes::V10(a) => a.source(),
         }
     }
 
-    fn get_specversion(&self) -> SpecVersion {
+    fn specversion(&self) -> SpecVersion {
         match self {
-            Attributes::V03(a) => a.get_specversion(),
-            Attributes::V10(a) => a.get_specversion(),
+            Attributes::V03(a) => a.specversion(),
+            Attributes::V10(a) => a.specversion(),
         }
     }
 
-    fn get_type(&self) -> &str {
+    fn ty(&self) -> &str {
         match self {
-            Attributes::V03(a) => a.get_type(),
-            Attributes::V10(a) => a.get_type(),
+            Attributes::V03(a) => a.ty(),
+            Attributes::V10(a) => a.ty(),
         }
     }
 
-    fn get_datacontenttype(&self) -> Option<&str> {
+    fn datacontenttype(&self) -> Option<&str> {
         match self {
-            Attributes::V03(a) => a.get_datacontenttype(),
-            Attributes::V10(a) => a.get_datacontenttype(),
+            Attributes::V03(a) => a.datacontenttype(),
+            Attributes::V10(a) => a.datacontenttype(),
         }
     }
 
-    fn get_dataschema(&self) -> Option<&Url> {
+    fn dataschema(&self) -> Option<&Url> {
         match self {
-            Attributes::V03(a) => a.get_dataschema(),
-            Attributes::V10(a) => a.get_dataschema(),
+            Attributes::V03(a) => a.dataschema(),
+            Attributes::V10(a) => a.dataschema(),
         }
     }
 
-    fn get_subject(&self) -> Option<&str> {
+    fn subject(&self) -> Option<&str> {
         match self {
-            Attributes::V03(a) => a.get_subject(),
-            Attributes::V10(a) => a.get_subject(),
+            Attributes::V03(a) => a.subject(),
+            Attributes::V10(a) => a.subject(),
         }
     }
 
-    fn get_time(&self) -> Option<&DateTime<Utc>> {
+    fn time(&self) -> Option<&DateTime<Utc>> {
         match self {
-            Attributes::V03(a) => a.get_time(),
-            Attributes::V10(a) => a.get_time(),
+            Attributes::V03(a) => a.time(),
+            Attributes::V10(a) => a.time(),
         }
     }
 }

--- a/src/event/data.rs
+++ b/src/event/data.rs
@@ -1,4 +1,6 @@
+use serde::export::Formatter;
 use std::convert::{Into, TryFrom};
+use std::fmt;
 
 /// Event [data attribute](https://github.com/cloudevents/spec/blob/master/spec.md#event-data) representation
 #[derive(Debug, PartialEq, Clone)]
@@ -99,6 +101,16 @@ impl TryFrom<Data> for String {
             Data::Binary(v) => Ok(String::from_utf8(v)?),
             Data::Json(v) => Ok(v.to_string()),
             Data::String(s) => Ok(s),
+        }
+    }
+}
+
+impl fmt::Display for Data {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Data::Binary(vec) => write!(f, "Binary data: {:?}", vec),
+            Data::String(s) => write!(f, "String data: {}", s),
+            Data::Json(j) => write!(f, "Json data: {}", j),
         }
     }
 }

--- a/src/event/format.rs
+++ b/src/event/format.rs
@@ -107,7 +107,7 @@ pub(crate) trait EventFormatDeserializer {
         let attributes = Self::deserialize_attributes(&mut map)?;
         let data = Self::deserialize_data(
             attributes
-                .get_datacontenttype()
+                .datacontenttype()
                 .unwrap_or("application/json"),
             &mut map,
         )?;

--- a/src/event/format.rs
+++ b/src/event/format.rs
@@ -106,9 +106,7 @@ pub(crate) trait EventFormatDeserializer {
     ) -> Result<Event, E> {
         let attributes = Self::deserialize_attributes(&mut map)?;
         let data = Self::deserialize_data(
-            attributes
-                .datacontenttype()
-                .unwrap_or("application/json"),
+            attributes.datacontenttype().unwrap_or("application/json"),
             &mut map,
         )?;
         let extensions = map

--- a/src/event/message.rs
+++ b/src/event/message.rs
@@ -17,7 +17,7 @@ impl StructuredDeserializer for Event {
 
 impl BinaryDeserializer for Event {
     fn deserialize_binary<R: Sized, V: BinarySerializer<R>>(self, mut visitor: V) -> Result<R> {
-        visitor = visitor.set_spec_version(self.get_specversion())?;
+        visitor = visitor.set_spec_version(self.specversion())?;
         visitor = self.attributes.deserialize_attributes(visitor)?;
         for (k, v) in self.extensions.into_iter() {
             visitor = visitor.set_extension(&k, v.into())?;

--- a/src/event/v03/attributes.rs
+++ b/src/event/v03/attributes.rs
@@ -88,35 +88,35 @@ impl<'a> Iterator for AttributesIntoIterator<'a> {
 }
 
 impl AttributesReader for Attributes {
-    fn get_id(&self) -> &str {
+    fn id(&self) -> &str {
         &self.id
     }
 
-    fn get_source(&self) -> &Url {
+    fn source(&self) -> &Url {
         &self.source
     }
 
-    fn get_specversion(&self) -> SpecVersion {
+    fn specversion(&self) -> SpecVersion {
         SpecVersion::V03
     }
 
-    fn get_type(&self) -> &str {
+    fn ty(&self) -> &str {
         &self.ty
     }
 
-    fn get_datacontenttype(&self) -> Option<&str> {
+    fn datacontenttype(&self) -> Option<&str> {
         self.datacontenttype.as_deref()
     }
 
-    fn get_dataschema(&self) -> Option<&Url> {
+    fn dataschema(&self) -> Option<&Url> {
         self.schemaurl.as_ref()
     }
 
-    fn get_subject(&self) -> Option<&str> {
+    fn subject(&self) -> Option<&str> {
         self.subject.as_deref()
     }
 
-    fn get_time(&self) -> Option<&DateTime<Utc>> {
+    fn time(&self) -> Option<&DateTime<Utc>> {
         self.time.as_ref()
     }
 }

--- a/src/event/v10/attributes.rs
+++ b/src/event/v10/attributes.rs
@@ -88,35 +88,35 @@ impl<'a> Iterator for AttributesIntoIterator<'a> {
 }
 
 impl AttributesReader for Attributes {
-    fn get_id(&self) -> &str {
+    fn id(&self) -> &str {
         &self.id
     }
 
-    fn get_source(&self) -> &Url {
+    fn source(&self) -> &Url {
         &self.source
     }
 
-    fn get_specversion(&self) -> SpecVersion {
+    fn specversion(&self) -> SpecVersion {
         SpecVersion::V10
     }
 
-    fn get_type(&self) -> &str {
+    fn ty(&self) -> &str {
         &self.ty
     }
 
-    fn get_datacontenttype(&self) -> Option<&str> {
+    fn datacontenttype(&self) -> Option<&str> {
         self.datacontenttype.as_deref()
     }
 
-    fn get_dataschema(&self) -> Option<&Url> {
+    fn dataschema(&self) -> Option<&Url> {
         self.dataschema.as_ref()
     }
 
-    fn get_subject(&self) -> Option<&str> {
+    fn subject(&self) -> Option<&str> {
         self.subject.as_deref()
     }
 
-    fn get_time(&self) -> Option<&DateTime<Utc>> {
+    fn time(&self) -> Option<&DateTime<Utc>> {
         self.time.as_ref()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,8 @@
 //!     .build()
 //!     .unwrap();
 //!
-//! println!("CloudEvent Id: {}", event.get_id());
-//! println!("CloudEvent Time: {}", event.get_time().unwrap());
+//! println!("CloudEvent Id: {}", event.id());
+//! println!("CloudEvent Time: {}", event.time().unwrap());
 //! ```
 //!
 //! If you're looking for Protocol Binding implementations, look at crates:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod event;
 /// Provides facilities to implement Protocol Bindings
 pub mod message;
 
+pub use event::Data;
 pub use event::Event;
 pub use event::{AttributesReader, AttributesWriter};
 pub use event::{EventBuilder, EventBuilderV03, EventBuilderV10};

--- a/tests/builder_v03.rs
+++ b/tests/builder_v03.rs
@@ -34,20 +34,20 @@ fn build_event() {
         .build()
         .unwrap();
 
-    assert_eq!(SpecVersion::V03, event.get_specversion());
-    assert_eq!(id, event.get_id());
-    assert_eq!(source, event.get_source().clone());
-    assert_eq!(ty, event.get_type());
-    assert_eq!(subject, event.get_subject().unwrap());
-    assert_eq!(time, event.get_time().unwrap().clone());
+    assert_eq!(SpecVersion::V03, event.specversion());
+    assert_eq!(id, event.id());
+    assert_eq!(source, event.source().clone());
+    assert_eq!(ty, event.ty());
+    assert_eq!(subject, event.subject().unwrap());
+    assert_eq!(time, event.time().unwrap().clone());
     assert_eq!(
         ExtensionValue::from(extension_value),
-        event.get_extension(extension_name).unwrap().clone()
+        event.extension(extension_name).unwrap().clone()
     );
-    assert_eq!(content_type, event.get_datacontenttype().unwrap());
-    assert_eq!(schema, event.get_dataschema().unwrap().clone());
+    assert_eq!(content_type, event.datacontenttype().unwrap());
+    assert_eq!(schema, event.dataschema().unwrap().clone());
 
-    let event_data: serde_json::Value = event.try_get_data().unwrap().unwrap();
+    let event_data: serde_json::Value = event.try_data().unwrap().unwrap();
     assert_eq!(data, event_data);
 }
 

--- a/tests/builder_v03.rs
+++ b/tests/builder_v03.rs
@@ -6,6 +6,7 @@ use cloudevents::event::{
     AttributesReader, EventBuilder, EventBuilderError, ExtensionValue, SpecVersion,
 };
 use cloudevents::EventBuilderV03;
+use std::convert::TryInto;
 use url::Url;
 
 #[test]
@@ -23,7 +24,7 @@ fn build_event() {
         "hello": "world"
     });
 
-    let event = EventBuilderV03::new()
+    let mut event = EventBuilderV03::new()
         .id(id)
         .source(source.clone())
         .ty(ty)
@@ -47,7 +48,7 @@ fn build_event() {
     assert_eq!(content_type, event.datacontenttype().unwrap());
     assert_eq!(schema, event.dataschema().unwrap().clone());
 
-    let event_data: serde_json::Value = event.try_data().unwrap().unwrap();
+    let event_data: serde_json::Value = event.take_data().2.unwrap().try_into().unwrap();
     assert_eq!(data, event_data);
 }
 

--- a/tests/builder_v10.rs
+++ b/tests/builder_v10.rs
@@ -6,6 +6,7 @@ use cloudevents::event::{
     AttributesReader, EventBuilder, EventBuilderError, ExtensionValue, SpecVersion,
 };
 use cloudevents::EventBuilderV10;
+use std::convert::TryInto;
 use url::Url;
 
 #[test]
@@ -23,7 +24,7 @@ fn build_event() {
         "hello": "world"
     });
 
-    let event = EventBuilderV10::new()
+    let mut event = EventBuilderV10::new()
         .id(id)
         .source(source.clone())
         .ty(ty)
@@ -47,7 +48,7 @@ fn build_event() {
     assert_eq!(content_type, event.datacontenttype().unwrap());
     assert_eq!(schema, event.dataschema().unwrap().clone());
 
-    let event_data: serde_json::Value = event.try_data().unwrap().unwrap();
+    let event_data: serde_json::Value = event.take_data().2.unwrap().try_into().unwrap();
     assert_eq!(data, event_data);
 }
 

--- a/tests/builder_v10.rs
+++ b/tests/builder_v10.rs
@@ -34,20 +34,20 @@ fn build_event() {
         .build()
         .unwrap();
 
-    assert_eq!(SpecVersion::V10, event.get_specversion());
-    assert_eq!(id, event.get_id());
-    assert_eq!(source, event.get_source().clone());
-    assert_eq!(ty, event.get_type());
-    assert_eq!(subject, event.get_subject().unwrap());
-    assert_eq!(time, event.get_time().unwrap().clone());
+    assert_eq!(SpecVersion::V10, event.specversion());
+    assert_eq!(id, event.id());
+    assert_eq!(source, event.source().clone());
+    assert_eq!(ty, event.ty());
+    assert_eq!(subject, event.subject().unwrap());
+    assert_eq!(time, event.time().unwrap().clone());
     assert_eq!(
         ExtensionValue::from(extension_value),
-        event.get_extension(extension_name).unwrap().clone()
+        event.extension(extension_name).unwrap().clone()
     );
-    assert_eq!(content_type, event.get_datacontenttype().unwrap());
-    assert_eq!(schema, event.get_dataschema().unwrap().clone());
+    assert_eq!(content_type, event.datacontenttype().unwrap());
+    assert_eq!(schema, event.dataschema().unwrap().clone());
 
-    let event_data: serde_json::Value = event.try_get_data().unwrap().unwrap();
+    let event_data: serde_json::Value = event.try_data().unwrap().unwrap();
     assert_eq!(data, event_data);
 }
 

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -3,6 +3,7 @@ use cloudevents::message::{BinaryDeserializer, Result, StructuredDeserializer};
 
 use cloudevents::{AttributesReader, EventBuilder, EventBuilderV03, EventBuilderV10};
 use test_data::*;
+use std::convert::TryInto;
 
 #[test]
 fn message_v03_roundtrip_structured() -> Result<()> {
@@ -18,10 +19,10 @@ fn message_v03_roundtrip_binary() -> Result<()> {
     //TODO this code smells because we're missing a proper way in the public APIs
     // to destructure an event and rebuild it
     let wanna_be_expected = v03::full_json_data();
-    let data: serde_json::Value = wanna_be_expected.try_get_data()?.unwrap();
+    let data: serde_json::Value = wanna_be_expected.data().unwrap().clone().try_into()?;
     let bytes = serde_json::to_vec(&data)?;
     let expected = EventBuilderV03::from(wanna_be_expected.clone())
-        .data(wanna_be_expected.get_datacontenttype().unwrap(), bytes)
+        .data(wanna_be_expected.datacontenttype().unwrap(), bytes)
         .build()
         .unwrap();
 
@@ -46,10 +47,10 @@ fn message_v10_roundtrip_binary() -> Result<()> {
     //TODO this code smells because we're missing a proper way in the public APIs
     // to destructure an event and rebuild it
     let wanna_be_expected = v10::full_json_data();
-    let data: serde_json::Value = wanna_be_expected.try_get_data()?.unwrap();
+    let data: serde_json::Value = wanna_be_expected.try_data()?.unwrap();
     let bytes = serde_json::to_vec(&data)?;
     let expected = EventBuilderV10::from(wanna_be_expected.clone())
-        .data(wanna_be_expected.get_datacontenttype().unwrap(), bytes)
+        .data(wanna_be_expected.datacontenttype().unwrap(), bytes)
         .build()
         .unwrap();
 

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -2,8 +2,8 @@ mod test_data;
 use cloudevents::message::{BinaryDeserializer, Result, StructuredDeserializer};
 
 use cloudevents::{AttributesReader, EventBuilder, EventBuilderV03, EventBuilderV10};
-use test_data::*;
 use std::convert::TryInto;
+use test_data::*;
 
 #[test]
 fn message_v03_roundtrip_structured() -> Result<()> {
@@ -47,7 +47,12 @@ fn message_v10_roundtrip_binary() -> Result<()> {
     //TODO this code smells because we're missing a proper way in the public APIs
     // to destructure an event and rebuild it
     let wanna_be_expected = v10::full_json_data();
-    let data: serde_json::Value = wanna_be_expected.try_data()?.unwrap();
+    let data: serde_json::Value = wanna_be_expected
+        .data()
+        .cloned()
+        .unwrap()
+        .try_into()
+        .unwrap();
     let bytes = serde_json::to_vec(&data)?;
     let expected = EventBuilderV10::from(wanna_be_expected.clone())
         .data(wanna_be_expected.datacontenttype().unwrap(), bytes)


### PR DESCRIPTION
Part of #79. Cleanup to follow the naming convention of getters as proposed by https://rust-lang.github.io/api-guidelines/checklist.html

Also:

* re-exporting `Data` in main mod
* Implemented fmt::Debug in event::Data