### PR TITLE
Renamed error variants of message::Error

### DIFF
--- a/cloudevents-sdk-rdkafka/src/kafka_producer_record.rs
+++ b/cloudevents-sdk-rdkafka/src/kafka_producer_record.rs
@@ -46,7 +46,7 @@ impl BinarySerializer<MessageRecord> for MessageRecord {
         self.headers = self.headers.add(
             &headers::ATTRIBUTES_TO_HEADERS
                 .get(name)
-                .ok_or(cloudevents::message::Error::UnrecognizedAttributeName {
+                .ok_or(cloudevents::message::Error::UnknownAttribute {
                     name: String::from(name),
                 })?
                 .clone()[..],

--- a/src/event/message.rs
+++ b/src/event/message.rs
@@ -122,7 +122,7 @@ mod tests {
     #[test]
     fn binary_deserializer_unrecognized_attribute_v03() {
         assert_eq!(
-            Error::UnrecognizedAttributeName {
+            Error::UnknownAttribute {
                 name: "dataschema".to_string()
             }
             .to_string(),
@@ -156,7 +156,7 @@ mod tests {
     #[test]
     fn binary_deserializer_unrecognized_attribute_v10() {
         assert_eq!(
-            Error::UnrecognizedAttributeName {
+            Error::UnknownAttribute {
                 name: "schemaurl".to_string()
             }
             .to_string(),

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -19,8 +19,8 @@ pub use event::Event;
 pub use extensions::ExtensionValue;
 pub(crate) use message::EventBinarySerializer;
 pub(crate) use message::EventStructuredSerializer;
-pub use spec_version::InvalidSpecVersion;
 pub use spec_version::SpecVersion;
+pub use spec_version::UnknownSpecVersion;
 pub use types::{TryIntoTime, TryIntoUrl};
 
 mod v03;

--- a/src/event/spec_version.rs
+++ b/src/event/spec_version.rs
@@ -43,28 +43,28 @@ impl fmt::Display for SpecVersion {
     }
 }
 
-/// Error representing an invalid [`SpecVersion`] string identifier
+/// Error representing an unknown [`SpecVersion`] string identifier
 #[derive(Debug)]
-pub struct InvalidSpecVersion {
+pub struct UnknownSpecVersion {
     spec_version_value: String,
 }
 
-impl fmt::Display for InvalidSpecVersion {
+impl fmt::Display for UnknownSpecVersion {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "Invalid specversion {}", self.spec_version_value)
     }
 }
 
-impl std::error::Error for InvalidSpecVersion {}
+impl std::error::Error for UnknownSpecVersion {}
 
 impl TryFrom<&str> for SpecVersion {
-    type Error = InvalidSpecVersion;
+    type Error = UnknownSpecVersion;
 
-    fn try_from(value: &str) -> Result<Self, InvalidSpecVersion> {
+    fn try_from(value: &str) -> Result<Self, UnknownSpecVersion> {
         match value {
             "0.3" => Ok(SpecVersion::V03),
             "1.0" => Ok(SpecVersion::V10),
-            _ => Err(InvalidSpecVersion {
+            _ => Err(UnknownSpecVersion {
                 spec_version_value: value.to_string(),
             }),
         }

--- a/src/event/v03/builder.rs
+++ b/src/event/v03/builder.rs
@@ -196,7 +196,7 @@ impl crate::event::message::AttributesSerializer for EventBuilder {
             "subject" => self.subject = Some(value.to_string()),
             "time" => self.time = Some(value.try_into()?),
             _ => {
-                return Err(crate::message::Error::UnrecognizedAttributeName {
+                return Err(crate::message::Error::UnknownAttribute {
                     name: name.to_string(),
                 })
             }

--- a/src/event/v10/builder.rs
+++ b/src/event/v10/builder.rs
@@ -196,7 +196,7 @@ impl crate::event::message::AttributesSerializer for EventBuilder {
             "subject" => self.subject = Some(value.to_string()),
             "time" => self.time = Some(value.try_into()?),
             _ => {
-                return Err(crate::message::Error::UnrecognizedAttributeName {
+                return Err(crate::message::Error::UnknownAttribute {
                     name: name.to_string(),
                 })
             }

--- a/src/message/error.rs
+++ b/src/message/error.rs
@@ -7,11 +7,11 @@ pub enum Error {
     WrongEncoding {},
     #[snafu(display("{}", source))]
     #[snafu(context(false))]
-    InvalidSpecVersion {
-        source: crate::event::InvalidSpecVersion,
+    UnknownSpecVersion {
+        source: crate::event::UnknownSpecVersion,
     },
-    #[snafu(display("Unrecognized attribute name: {}", name))]
-    UnrecognizedAttributeName { name: String },
+    #[snafu(display("Unknown attribute in this spec version: {}", name))]
+    UnknownAttribute { name: String },
     #[snafu(display("Error while building the final event: {}", source))]
     #[snafu(context(false))]
     EventBuilderError {

--- a/src/message/error.rs
+++ b/src/message/error.rs
@@ -33,7 +33,9 @@ pub enum Error {
     #[snafu(context(false))]
     IOError { source: std::io::Error },
     #[snafu(display("Other error: {}", source))]
-    Other { source: Box<dyn std::error::Error> },
+    Other {
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 /// Result type alias for return values during serialization/deserialization process


### PR DESCRIPTION
Also `message::Error` now implements send and sync

Part of #79

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>