### PR TITLE
Align with C-COMMON-TRAITS criteria

### DIFF
--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use url::Url;
 
 /// Value of a CloudEvent attribute
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AttributeValue<'a> {
     SpecVersion(SpecVersion),
     String(&'a str),
@@ -110,7 +110,7 @@ impl<'a> Iterator for AttributesIter<'a> {
 }
 
 /// Union type representing one of the possible context attributes structs
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Attributes {
     V03(AttributesV03),
     V10(AttributesV10),

--- a/src/event/data.rs
+++ b/src/event/data.rs
@@ -3,7 +3,7 @@ use std::convert::{Into, TryFrom};
 use std::fmt;
 
 /// Event [data attribute](https://github.com/cloudevents/spec/blob/master/spec.md#event-data) representation
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Data {
     /// Event has a binary payload
     Binary(Vec<u8>),

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -7,6 +7,7 @@ use chrono::{DateTime, Utc};
 use delegate_attr::delegate;
 use std::collections::HashMap;
 use url::Url;
+use std::fmt;
 
 /// Data structure that represents a [CloudEvent](https://github.com/cloudevents/spec/blob/master/spec.md).
 /// It provides methods to get the attributes through [`AttributesReader`]
@@ -39,7 +40,7 @@ use url::Url;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Event {
     pub(crate) attributes: Attributes,
     pub(crate) data: Option<Data>,
@@ -74,6 +75,20 @@ impl Default for Event {
             data: None,
             extensions: HashMap::default(),
         }
+    }
+}
+
+impl fmt::Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "CloudEvent:\n")?;
+        self.iter()
+            .map(|(name, val)| write!(f, "  {}: '{}'\n", name, val))
+            .collect::<fmt::Result>()?;
+        match self.data() {
+            Some(data) => write!(f, "  {}", data)?,
+            None => write!(f, "  No data")?
+        }
+        write!(f, "\n")
     }
 }
 

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -6,8 +6,8 @@ use crate::event::attributes::DataAttributesWriter;
 use chrono::{DateTime, Utc};
 use delegate_attr::delegate;
 use std::collections::HashMap;
-use url::Url;
 use std::fmt;
+use url::Url;
 
 /// Data structure that represents a [CloudEvent](https://github.com/cloudevents/spec/blob/master/spec.md).
 /// It provides methods to get the attributes through [`AttributesReader`]
@@ -86,7 +86,7 @@ impl fmt::Display for Event {
             .collect::<fmt::Result>()?;
         match self.data() {
             Some(data) => write!(f, "  {}", data)?,
-            None => write!(f, "  No data")?
+            None => write!(f, "  No data")?,
         }
         write!(f, "\n")
     }

--- a/src/event/extensions.rs
+++ b/src/event/extensions.rs
@@ -1,7 +1,8 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::convert::From;
+use std::fmt;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 /// Represents all the possible [CloudEvents extension](https://github.com/cloudevents/spec/blob/master/spec.md#extension-context-attributes) values
 pub enum ExtensionValue {
@@ -57,5 +58,15 @@ impl ExtensionValue {
         S: Into<bool>,
     {
         ExtensionValue::from(s.into())
+    }
+}
+
+impl fmt::Display for ExtensionValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExtensionValue::String(s) => f.write_str(s),
+            ExtensionValue::Boolean(b) => f.serialize_bool(*b),
+            ExtensionValue::Integer(i) => f.serialize_i64(*i),
+        }
     }
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -10,7 +10,6 @@ mod spec_version;
 mod types;
 
 pub use attributes::Attributes;
-pub(crate) use attributes::AttributesIter;
 pub use attributes::{AttributeValue, AttributesReader, AttributesWriter};
 pub use builder::Error as EventBuilderError;
 pub use builder::EventBuilder;

--- a/src/event/v03/attributes.rs
+++ b/src/event/v03/attributes.rs
@@ -20,7 +20,7 @@ pub(crate) const ATTRIBUTE_NAMES: [&'static str; 8] = [
 ];
 
 /// Data structure representing [CloudEvents V0.3 context attributes](https://github.com/cloudevents/spec/blob/v0.3/spec.md#context-attributes)
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Attributes {
     pub(crate) id: String,
     pub(crate) ty: String,

--- a/src/event/v10/attributes.rs
+++ b/src/event/v10/attributes.rs
@@ -20,7 +20,7 @@ pub(crate) const ATTRIBUTE_NAMES: [&'static str; 8] = [
 ];
 
 /// Data structure representing [CloudEvents V1.0 context attributes](https://github.com/cloudevents/spec/blob/v1.0/spec.md#context-attributes)
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct Attributes {
     pub(crate) id: String,
     pub(crate) ty: String,

--- a/src/message/encoding.rs
+++ b/src/message/encoding.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 /// Represents one of the possible [message encodings/modes](https://github.com/cloudevents/spec/blob/v1.0/spec.md#message)
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Encoding {
     STRUCTURED,
     BINARY,

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -2,8 +2,11 @@ use crate::event::ExtensionValue;
 use chrono::{DateTime, Utc};
 use std::convert::TryInto;
 use url::Url;
+use std::fmt;
+use serde::export::Formatter;
 
 /// Union type representing a [CloudEvent context attribute type](https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system)
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum MessageAttributeValue {
     Boolean(bool),
     Integer(i64),
@@ -39,16 +42,16 @@ impl TryInto<Url> for MessageAttributeValue {
     }
 }
 
-impl ToString for MessageAttributeValue {
-    fn to_string(&self) -> String {
+impl fmt::Display for MessageAttributeValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            MessageAttributeValue::Boolean(b) => b.to_string(),
-            MessageAttributeValue::Integer(i) => i.to_string(),
-            MessageAttributeValue::String(s) => s.clone(),
-            MessageAttributeValue::Binary(v) => base64::encode(v),
-            MessageAttributeValue::Uri(u) => u.to_string(),
-            MessageAttributeValue::UriRef(u) => u.to_string(),
-            MessageAttributeValue::DateTime(d) => d.to_rfc3339(),
+            MessageAttributeValue::Boolean(b) => write!(f, "{}", b),
+            MessageAttributeValue::Integer(i) => write!(f, "{}", i),
+            MessageAttributeValue::String(s) => write!(f, "{}", s),
+            MessageAttributeValue::Binary(v) => write!(f, "{}", base64::encode(v)),
+            MessageAttributeValue::Uri(u) => write!(f, "{}", u.to_string()),
+            MessageAttributeValue::UriRef(u) => write!(f, "{}", u.to_string()),
+            MessageAttributeValue::DateTime(d) => write!(f, "{}", d.to_rfc3339()),
         }
     }
 }

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -1,9 +1,9 @@
 use crate::event::ExtensionValue;
 use chrono::{DateTime, Utc};
-use std::convert::TryInto;
-use url::Url;
-use std::fmt;
 use serde::export::Formatter;
+use std::convert::TryInto;
+use std::fmt;
+use url::Url;
 
 /// Union type representing a [CloudEvent context attribute type](https://github.com/cloudevents/spec/blob/v1.0/spec.md#type-system)
 #[derive(PartialEq, Eq, Debug, Clone)]


### PR DESCRIPTION
Aligned with C-COMMON-TRAITS criteria, part of https://github.com/cloudevents/sdk-rust/issues/79

* Implemented `Eq` for several public structs
* Implemented `Display` for `Event`
* Implemented `Display` for `ExtensionValue`
* Removed bad implementation of `ToString` in `MessageAttributeValue` and replaced with implementation of `Display`