### PR TITLE
[WIP] Tokio 1.0 related bumps

### DIFF
--- a/cloudevents-sdk-rdkafka/Cargo.toml
+++ b/cloudevents-sdk-rdkafka/Cargo.toml
@@ -13,10 +13,10 @@ categories = ["web-programming", "encoding"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "^0.5"
+bytes = "^1.0"
 cloudevents-sdk = { version = "0.3.0", path = ".." }
 lazy_static = "1.4.0"
-rdkafka = { version = "^0.24", features = ["cmake-build"] }
+rdkafka = { version = "^0.25", features = ["cmake-build"] }
 
 [dev-dependencies]
 url = { version = "^2.1" }

--- a/cloudevents-sdk-reqwest/Cargo.toml
+++ b/cloudevents-sdk-reqwest/Cargo.toml
@@ -16,16 +16,16 @@ categories = ["web-programming", "encoding", "web-programming::http-client"]
 async-trait = "^0.1.33"
 cloudevents-sdk = { version = "0.3.0", path = ".." }
 lazy_static = "1.4.0"
-bytes = "^0.5"
+bytes = "^1.0"
 
 [dependencies.reqwest]
-version = "0.10.4"
+version = "^0.11"
 default-features = false
 features = ["rustls-tls"]
 
 [dev-dependencies]
 mockito = "0.25.1"
-tokio = { version = "^0.2", features = ["full"] }
+tokio = { version = "^1.0", features = ["full"] }
 url = { version = "^2.1" }
 serde_json = "^1.0"
 chrono = { version = "^0.4", features = ["serde"] }

--- a/cloudevents-sdk-warp/Cargo.toml
+++ b/cloudevents-sdk-warp/Cargo.toml
@@ -9,13 +9,13 @@ license-file = "../LICENSE"
 [dependencies]
 cloudevents-sdk = { path = ".." }
 lazy_static = "1.4.0"
-bytes = "^0.5"
-warp = "0.2"
+bytes = "^1.0"
+warp = "^0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "^0.14"
 
 [dev-dependencies]
-tokio = { version = "^0.2", features = ["full"] }
+tokio = { version = "^1.0", features = ["full"] }
 url = { version = "^2.1" }
 serde_json = "^1.0"
 chrono = { version = "^0.4", features = ["serde"] }

--- a/example-projects/rdkafka-example/Cargo.toml
+++ b/example-projects/rdkafka-example/Cargo.toml
@@ -11,12 +11,12 @@ async-trait = "^0.1.33"
 cloudevents-sdk = { path = "../.." }
 cloudevents-sdk-rdkafka = { path = "../../cloudevents-sdk-rdkafka" }
 lazy_static = "1.4.0"
-bytes = "^0.5"
+bytes = "^1.0"
 url = { version = "^2.1", features = ["serde"] }
 serde_json = "^1.0"
 futures = "^0.3"
-tokio = { version = "^0.2", features = ["full"] }
+tokio = { version = "^1.0", features = ["full"] }
 clap = "2.33.1"
-rdkafka = { version = "^0.24", features = ["cmake-build"] }
+rdkafka = { version = "^0.25", features = ["cmake-build"] }
 
 [workspace]

--- a/example-projects/reqwest-wasm-example/Cargo.toml
+++ b/example-projects/reqwest-wasm-example/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-reqwest = "0.10.4"
+reqwest = "^0.11"
 cloudevents-sdk = { path = "../.." }
 cloudevents-sdk-reqwest = { path = "../../cloudevents-sdk-reqwest" }
 url = { version = "^2.1" }

--- a/example-projects/warp-example/Cargo.toml
+++ b/example-projects/warp-example/Cargo.toml
@@ -9,8 +9,8 @@ license-file = "../LICENSE"
 [dependencies]
 cloudevents-sdk = { path = "../.." }
 cloudevents-sdk-warp = { path = "../../cloudevents-sdk-warp"}
-warp = "0.2"
-tokio = { version = "^0.2", features = ["full"] }
+warp = "^0.3"
+tokio = { version = "^1.0", features = ["full"] }
 
 [workspace]
 


### PR DESCRIPTION
Fix #112. Version bumps to update all our integration packages to use latest tokio 1.0 and bytes 1.0 release.

* Updated warp to 0.3
* Updated rdkafka to 0.25
* Updated reqwest to 0.11

actix-web still didn't released a final version of 4.0 including tokio 1.0, so we'll do this bump later 

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>