### PR TITLE
tide sdk and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,13 @@ members = [
   "cloudevents-sdk-actix-web",
   "cloudevents-sdk-reqwest",
   "cloudevents-sdk-rdkafka",
-  "cloudevents-sdk-warp"
+  "cloudevents-sdk-warp",
+  "cloudevents-sdk-tide"
 ]
 exclude = [
   "example-projects/actix-web-example",
   "example-projects/reqwest-wasm-example",
   "example-projects/rdkafka-example",
   "example-projects/warp-example",
+  "example-projects/tide-example",
 ]

--- a/cloudevents-sdk-actix-web/src/server_request.rs
+++ b/cloudevents-sdk-actix-web/src/server_request.rs
@@ -144,12 +144,10 @@ mod private {
 mod tests {
     use super::*;
     use actix_web::test;
-    use url::Url;
 
     use chrono::Utc;
     use cloudevents::{EventBuilder, EventBuilderV10};
     use serde_json::json;
-    use std::str::FromStr;
 
     #[actix_rt::test]
     async fn test_request() {
@@ -186,7 +184,7 @@ mod tests {
         let expected = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             //TODO this is required now because the message deserializer implictly set default values
             // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
             .time(time)

--- a/cloudevents-sdk-actix-web/src/server_response.rs
+++ b/cloudevents-sdk-actix-web/src/server_response.rs
@@ -107,21 +107,19 @@ mod private {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use url::Url;
 
     use actix_web::http::StatusCode;
     use actix_web::test;
     use cloudevents::{EventBuilder, EventBuilderV10};
     use futures::TryStreamExt;
     use serde_json::json;
-    use std::str::FromStr;
 
     #[actix_rt::test]
     async fn test_response() {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost/").unwrap())
+            .source("http://localhost/")
             .extension("someint", "10")
             .build()
             .unwrap();
@@ -164,7 +162,7 @@ mod tests {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .data("application/json", j.clone())
             .extension("someint", "10")
             .build()
@@ -193,7 +191,7 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
-            "http://localhost/"
+            "http://localhost"
         );
         assert_eq!(
             resp.headers()

--- a/cloudevents-sdk-reqwest/src/client_request.rs
+++ b/cloudevents-sdk-reqwest/src/client_request.rs
@@ -95,7 +95,6 @@ mod tests {
     use cloudevents::message::StructuredDeserializer;
     use cloudevents::{EventBuilder, EventBuilderV10};
     use serde_json::json;
-    use url::Url;
 
     #[tokio::test]
     async fn test_request() {
@@ -112,7 +111,7 @@ mod tests {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost/").unwrap())
+            .source("http://localhost/")
             .extension("someint", "10")
             .build()
             .unwrap();
@@ -147,7 +146,7 @@ mod tests {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost/")
             .data("application/json", j.clone())
             .extension("someint", "10")
             .build()
@@ -173,7 +172,7 @@ mod tests {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .data("application/json", j.clone())
             .extension("someint", "10")
             .build()

--- a/cloudevents-sdk-reqwest/src/client_response.rs
+++ b/cloudevents-sdk-reqwest/src/client_response.rs
@@ -139,8 +139,6 @@ mod tests {
     use chrono::Utc;
     use cloudevents::{EventBuilder, EventBuilderV10};
     use serde_json::json;
-    use std::str::FromStr;
-    use url::Url;
 
     #[tokio::test]
     async fn test_response() {
@@ -162,7 +160,7 @@ mod tests {
             //TODO this is required now because the message deserializer implictly set default values
             // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
             .time(time)
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .extension("someint", "10")
             .build()
             .unwrap();
@@ -204,7 +202,7 @@ mod tests {
             //TODO this is required now because the message deserializer implictly set default values
             // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
             .time(time)
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost/")
             .data("application/json", j.to_string().into_bytes())
             .extension("someint", "10")
             .build()
@@ -234,7 +232,7 @@ mod tests {
             //TODO this is required now because the message deserializer implictly set default values
             // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
             .time(time)
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .data("application/json", j.clone())
             .extension("someint", "10")
             .build()

--- a/cloudevents-sdk-tide/Cargo.toml
+++ b/cloudevents-sdk-tide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudevents-sdk-tide"
-version = "0.0.1"
+version = "0.3.1"
 authors = ["Anton Whalley <anton@venshare.com>"]
 license-file = "../LICENSE"
 edition = "2018"
@@ -18,6 +18,7 @@ tide = { version = "0.16" }
 lazy_static = "1.4.0"
 http-types = "2.10.0"
 bytes = "^0.5"
+async-trait = "0.1.50"
 
 [dev-dependencies]
 serde = { version = "1.0.117", features = ["derive"] }

--- a/cloudevents-sdk-tide/Cargo.toml
+++ b/cloudevents-sdk-tide/Cargo.toml
@@ -26,5 +26,3 @@ chrono = { version = "^0.4", features = ["serde"] }
 version-sync = "^0.9"
 async-std = { version = "1", features = ["attributes"] }
 tide-testing = "0.1.3"
-
-

--- a/cloudevents-sdk-tide/Cargo.toml
+++ b/cloudevents-sdk-tide/Cargo.toml
@@ -18,7 +18,7 @@ tide = { version = "0.16" }
 lazy_static = "1.4.0"
 http-types = "2.10.0"
 bytes = "^0.5"
-async-trait = "0.1.50"
+
 
 [dev-dependencies]
 serde = { version = "1.0.117", features = ["derive"] }

--- a/cloudevents-sdk-tide/Cargo.toml
+++ b/cloudevents-sdk-tide/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "cloudevents-sdk-tide"
+version = "0.0.1"
+authors = ["Anton Whalley <anton@venshare.com>"]
+license-file = "../LICENSE"
+edition = "2018"
+description = "CloudEvents official Rust SDK - Tide integration"
+documentation = "https://docs.rs/cloudevents-sdk-tide"
+repository = "https://github.com/cloudevents/sdk-rust"
+readme = "README.md"
+categories = ["web-programming", "encoding", "web-programming::http-server"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cloudevents-sdk = { version = "0.3.1", path = ".." }
+tide = { version = "0.16" }
+lazy_static = "1.4.0"
+http-types = "2.10.0"
+bytes = "^0.5"
+
+[dev-dependencies]
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "^1.0"
+chrono = { version = "^0.4", features = ["serde"] }
+version-sync = "^0.9"
+async-std = { version = "1", features = ["attributes"] }
+tide-testing = "0.1.3"
+
+

--- a/cloudevents-sdk-tide/src/headers.rs
+++ b/cloudevents-sdk-tide/src/headers.rs
@@ -1,0 +1,49 @@
+use cloudevents::event::SpecVersion;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::str::FromStr;
+use tide::http::headers::{HeaderName, HeaderValue};
+
+macro_rules! header_to_str {
+    ($header_value:expr) => {
+        $header_value.unwrap().as_str()
+    };
+}
+
+macro_rules! str_name_to_header {
+    ($attribute:expr) => {
+        tide::http::headers::HeaderName::from_str($attribute).map_err(|e| {
+            cloudevents::message::Error::Other {
+                source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, e)),
+            }
+        })
+    };
+}
+
+macro_rules! attribute_name_to_header {
+    ($attribute:expr) => {
+        str_name_to_header!(&["ce-", $attribute].concat())
+    };
+}
+
+fn attributes_to_headers(
+    it: impl Iterator<Item = &'static str>,
+) -> HashMap<&'static str, HeaderName> {
+    it.map(|s| {
+        if s == "datacontenttype" {
+            (s, tide::http::headers::CONTENT_TYPE)
+        } else {
+            (s, attribute_name_to_header!(s).unwrap())
+        }
+    })
+    .collect()
+}
+
+lazy_static! {
+    pub(crate) static ref ATTRIBUTES_TO_HEADERS: HashMap<&'static str, HeaderName> =
+        attributes_to_headers(SpecVersion::all_attribute_names());
+    pub(crate) static ref SPEC_VERSION_HEADER: HeaderName =
+        HeaderName::from_str("ce-specversion").unwrap();
+    pub(crate) static ref CLOUDEVENTS_JSON_HEADER: HeaderValue =
+        HeaderValue::from_str("application/cloudevents+json").unwrap();
+}

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -24,7 +24,7 @@
 //! To serialize a CloudEvent to an HTTP response:
 //!
 //! ```
-//! use cloudevents_sdk_tide::ResponseBuilderExt;
+//! use cloudevents_sdk_tide::ResponseExt;
 //! use tide::{Request, Response, Result};
 //! use cloudevents::{EventBuilderV10, EventBuilder};
 //! use serde_json::json;
@@ -58,5 +58,5 @@ pub use server_request::request_to_event;
 pub use server_request::RequestDeserializer;
 pub use server_request::RequestExt;
 pub use server_response::event_to_response;
-pub use server_response::ResponseBuilderExt;
+pub use server_response::ResponseExt;
 pub use server_response::ResponseSerializer;

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -15,7 +15,7 @@
 //!     req.insert_header("ce-type", "example.test");
 //!     req.insert_header("ce-source", "http://localhost/");
 //!     let bytes = req.body_bytes().await.unwrap();
-//!     let event : Event = req.to_event(bytes)?;
+//!     let event : Event = req.to_event(bytes).await?;
 //!     let resp = Response::builder(200).body(Body::from_json(&event)?).build();
 //!     Ok(resp)
 //! }
@@ -38,7 +38,7 @@
 //!                 .data("application/json", json!({"hello": "world"}))
 //!                 .build()
 //!                 .expect("No error while building the event"),
-//!         )?
+//!         ).await?
 //!     )
 //! }
 //! ```

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -53,10 +53,10 @@ mod headers;
 mod server_request;
 mod server_response;
 
+pub use cloudevents::Event;
 pub use server_request::request_to_event;
 pub use server_request::RequestDeserializer;
 pub use server_request::RequestExt;
 pub use server_response::event_to_response;
 pub use server_response::ResponseBuilderExt;
 pub use server_response::ResponseSerializer;
-pub use cloudevents::Event;

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -59,3 +59,4 @@ pub use server_request::RequestExt;
 pub use server_response::event_to_response;
 pub use server_response::ResponseBuilderExt;
 pub use server_response::ResponseSerializer;
+pub use cloudevents::Event;

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -1,0 +1,61 @@
+//! This crate integrates the [cloudevents-sdk](https://docs.rs/cloudevents-sdk) with [tide](https://docs.rs/tide/) to easily send and receive CloudEvents.
+//!
+//! To deserialize an HTTP request as CloudEvent:
+//!
+//! ```
+//! use cloudevents::Event;
+//! use cloudevents_sdk_tide::{ RequestExt };
+//! use tide::{Request, Body, Response};
+//!
+//! pub async fn index(mut req: Request<()>) -> tide::Result {
+//!     // The req headers should be set by the client but included here for clarity.
+//!     req.insert_header("content-type", "application/json");
+//!     req.insert_header("ce-specversion", "1.0");
+//!     req.insert_header("ce-id", "0001");
+//!     req.insert_header("ce-type", "example.test");
+//!     req.insert_header("ce-source", "http://localhost/");
+//!     let bytes = req.body_bytes().await.unwrap();
+//!     let event : Event = req.to_event(bytes)?;
+//!     let resp = Response::builder(200).body(Body::from_json(&event)?).build();
+//!     Ok(resp)
+//! }
+//!```
+//!
+//! To serialize a CloudEvent to an HTTP response:
+//!
+//! ```
+//! use cloudevents_sdk_tide::ResponseBuilderExt;
+//! use tide::{Request, Response, Result};
+//! use cloudevents::{EventBuilderV10, EventBuilder};
+//! use serde_json::json;
+//!
+//! pub async fn index(req: Request<()>) -> tide::Result {
+//!     Ok(Response::new(200).event(
+//!             EventBuilderV10::new()
+//!                 .id("0001")
+//!                 .ty("example.test")
+//!                 .source("http://localhost/")
+//!                 .data("application/json", json!({"hello": "world"}))
+//!                 .build()
+//!                 .expect("No error while building the event"),
+//!         )?
+//!     )
+//! }
+//! ```
+//!
+//! Check out the [cloudevents-sdk](https://docs.rs/cloudevents-sdk) docs for more details on how to use [`cloudevents::Event`]
+
+#![doc(html_root_url = "https://docs.rs/cloudevents-sdk-tide/0.0.1")]
+#![deny(broken_intra_doc_links)]
+
+#[macro_use]
+mod headers;
+mod server_request;
+mod server_response;
+
+pub use server_request::request_to_event;
+pub use server_request::RequestDeserializer;
+pub use server_request::RequestExt;
+pub use server_response::event_to_response;
+pub use server_response::ResponseBuilderExt;
+pub use server_response::ResponseSerializer;

--- a/cloudevents-sdk-tide/src/lib.rs
+++ b/cloudevents-sdk-tide/src/lib.rs
@@ -14,8 +14,7 @@
 //!     req.insert_header("ce-id", "0001");
 //!     req.insert_header("ce-type", "example.test");
 //!     req.insert_header("ce-source", "http://localhost/");
-//!     let bytes = req.body_bytes().await.unwrap();
-//!     let event : Event = req.to_event(bytes).await?;
+//!     let event : Event = req.to_event().await?;
 //!     let resp = Response::builder(200).body(Body::from_json(&event)?).build();
 //!     Ok(resp)
 //! }

--- a/cloudevents-sdk-tide/src/server_request.rs
+++ b/cloudevents-sdk-tide/src/server_request.rs
@@ -1,0 +1,291 @@
+use super::headers;
+use bytes::{Bytes, BytesMut};
+use cloudevents::event::SpecVersion;
+use cloudevents::message::{
+    BinaryDeserializer, BinarySerializer, Encoding, MessageAttributeValue, MessageDeserializer,
+    Result, StructuredDeserializer, StructuredSerializer,
+};
+use cloudevents::{message, Event};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use tide::{Error, Request};
+
+/// Wrapper for [`HttpRequest`] that implements [`MessageDeserializer`] trait.
+pub struct RequestDeserializer {
+    headers: HashMap<String, String>,
+    body: Bytes,
+}
+
+impl RequestDeserializer {
+    pub fn new(headers: HashMap<String, String>, body: Bytes) -> RequestDeserializer {
+        RequestDeserializer { headers, body }
+    }
+}
+
+impl<'a> BinaryDeserializer for RequestDeserializer {
+    fn deserialize_binary<R: Sized, V: BinarySerializer<R>>(self, mut visitor: V) -> Result<R> {
+        if self.encoding() != Encoding::BINARY {
+            return Err(message::Error::WrongEncoding {});
+        }
+
+        let versionheader = match self.headers.get("ce-specversion") {
+            Some(s) => s.as_str(),
+            None => "",
+        };
+        let spec_version = SpecVersion::try_from(versionheader)?;
+
+        visitor = visitor.set_spec_version(spec_version.clone())?;
+
+        let attributes = spec_version.attribute_names();
+
+        for (k, _) in self.headers.iter().filter(|&(k, _)| {
+            headers::SPEC_VERSION_HEADER.ne(k.as_str()) && k.as_str().starts_with("ce-")
+        }) {
+            let name = &k.as_str()["ce-".len()..];
+
+            if attributes.contains(&name) {
+                visitor = visitor.set_attribute(
+                    name,
+                    MessageAttributeValue::String(String::from(header_to_str!(self
+                        .headers
+                        .get(k)))),
+                )?
+            } else {
+                visitor = visitor.set_extension(
+                    name,
+                    MessageAttributeValue::String(String::from(header_to_str!(self
+                        .headers
+                        .get(k)))),
+                )?
+            }
+        }
+
+        if let Some(hv) = self.headers.get("content-type") {
+            visitor = visitor.set_attribute(
+                "datacontenttype",
+                MessageAttributeValue::String(String::from(hv.as_str())),
+            )?
+        }
+
+        if !self.body.is_empty() {
+            visitor.end_with_data(self.body.to_vec())
+        } else {
+            visitor.end()
+        }
+    }
+}
+
+impl<'a> StructuredDeserializer for RequestDeserializer {
+    fn deserialize_structured<R: Sized, V: StructuredSerializer<R>>(self, visitor: V) -> Result<R> {
+        if self.encoding() != Encoding::STRUCTURED {
+            return Err(message::Error::WrongEncoding {});
+        }
+        visitor.set_structured_event(self.body.to_vec())
+    }
+}
+
+impl<'a> MessageDeserializer for RequestDeserializer {
+    fn encoding(&self) -> Encoding {
+        let contentheader = match self.headers.get("content-type") {
+            Some(s) => s.as_str(),
+            None => "",
+        };
+        if contentheader == "application/cloudevents+json" {
+            Encoding::STRUCTURED
+        } else if self
+            .headers
+            .get(super::headers::SPEC_VERSION_HEADER.as_str())
+            .is_some()
+        {
+            Encoding::BINARY
+        } else {
+            Encoding::UNKNOWN
+        }
+    }
+}
+
+/// Method to transform an incoming [`HttpRequest`] to [`Event`].
+pub fn request_to_event(
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+) -> std::result::Result<Event, tide::Error> {
+    let mut bytes = BytesMut::with_capacity(body.len());
+    bytes.extend_from_slice(body.as_slice());
+    MessageDeserializer::into_event(RequestDeserializer::new(headers, bytes.freeze()))
+        .map_err(|e| Error::new(400, e))
+}
+
+/// Extention Trait for [`Request`] which acts as a wrapper for the function [`request_to_event()`].
+///
+/// This trait is sealed and cannot be implemented for types outside of this crate.
+#[allow(patterns_in_fns_without_body)]
+pub trait RequestExt: private::Sealed {
+    /// Convert this [`HttpRequest`] into an [`Event`].
+    fn to_event(&self, mut body: Vec<u8>) -> std::result::Result<Event, tide::Error>;
+}
+
+impl<State> RequestExt for Request<State> {
+    fn to_event(&self, body: Vec<u8>) -> std::result::Result<Event, tide::Error> {
+        let mut headers = HashMap::new();
+        for (n, v) in self.iter() {
+            headers.insert(String::from(n.as_str()), String::from(v.as_str()));
+        }
+        request_to_event(headers, body)
+    }
+}
+
+mod private {
+    // Sealing the RequestExt
+    pub trait Sealed {}
+    impl<State> Sealed for tide::Request<State> {}
+}
+// : Unpin + Clone + Send + Sync + 'static
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // use chrono::Utc;
+    use cloudevents::{EventBuilder, EventBuilderV10};
+    use serde_json::{json, Value};
+    use tide::{Body, Request};
+    use tide_testing::TideTestingExt;
+
+    #[async_std::test]
+    async fn test_request() {
+        let mut app = tide::new();
+        app.at("/").post(|mut req: Request<()>| async move {
+            let expected = EventBuilderV10::new()
+                .id("0001")
+                .ty("example.test")
+                .source("http://localhost/")
+                .data(
+                    "application/octet-stream",
+                    String::from("hello").into_bytes(),
+                )
+                .build()
+                .unwrap();
+
+            let body = req.body_bytes().await.unwrap();
+            let evtresp: Event = req.to_event(body).unwrap();
+
+            assert_eq!(expected, evtresp);
+            Ok(Body::from_json(&evtresp)?)
+        });
+
+        match app
+            .post("/")
+            .body(tide::Body::from_string("hello".into()))
+            .content_type("application/octet-stream")
+            .header("ce-specversion", "1.0")
+            .header("ce-id", "0001")
+            .header("ce-type", "example.test")
+            .header("ce-source", "http://localhost/")
+            .recv_string()
+            .await
+        {
+            Ok(r) => {
+                println!("{}", r);
+                r
+            }
+            Err(e) => panic!("Get String Failed {:?}", e),
+        };
+    }
+
+    #[async_std::test]
+    async fn test_request_with_full_data() {
+        let mut app = tide::new();
+        app.at("/").post(|mut req: Request<()>| async move {
+            let body = req.body_bytes().await.unwrap();
+            let expected = EventBuilderV10::new()
+                .id("0001")
+                .ty("example.test")
+                .source("http://localhost/")
+                //TODO this is required now because the message deserializer implictly set default values
+                // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
+                .data(
+                    "application/json",
+                    r#"{"hello":"world"}"#.as_bytes().to_vec(),
+                )
+                .extension("someint", "10")
+                .build()
+                .unwrap();
+
+            let evtresp: Event = req.to_event(body.to_vec()).unwrap();
+            assert_eq!(expected, evtresp);
+            Ok(Body::from_json(&evtresp)?)
+        });
+
+        match app
+            .post("/")
+            .body(tide::Body::from_string(r#"{"hello":"world"}"#.into()))
+            .content_type("application/json")
+            .header("ce-specversion", "1.0")
+            .header("ce-id", "0001")
+            .header("ce-type", "example.test")
+            .header("ce-source", "http://localhost/")
+            .header("ce-someint", "10")
+            .recv_string()
+            .await
+        {
+            Ok(r) => {
+                println!("{}", r);
+                r
+            }
+            Err(e) => panic!("Get String Failed {:?}", e),
+        };
+    }
+    #[derive(Clone)]
+    struct State {}
+    #[async_std::test]
+    async fn test_request_with_cloudevent() {
+        let state = State {};
+        let mut app = tide::with_state(state);
+        app.at("/").post(|mut req: Request<State>| async move {
+            let body = req.body_string().await.unwrap();
+            let expecteddata = json!({ "hello":"world" });
+            let j: Value = serde_json::from_str(&body).unwrap();
+            let vec: Vec<u8> = serde_json::to_vec(&j).unwrap();
+            let expected = EventBuilderV10::new()
+                .id("0001")
+                .ty("example.test")
+                .source("http://localhost/")
+                .data("application/cloudevents+json", expecteddata)
+                .extension("someint", "10")
+                .build()
+                .unwrap();
+
+            let evtresp: Event = req.to_event(vec).unwrap();
+            assert_eq!(expected, evtresp);
+            Ok(Body::from_json(&evtresp)?)
+        });
+
+        match app
+            .post("/")
+            .body(tide::Body::from_string(
+                r#"{
+                "datacontenttype" : "application/cloudevents+json",
+                "data" : { "hello":"world" },
+                "specversion" : "1.0",
+                "id" : "0001",
+                "type" : "example.test",
+                "source" : "http://localhost/",
+                "someint" : "10"
+            }"#
+                .into(),
+            ))
+            .content_type("application/cloudevents+json")
+            .header("ce-specversion", "1.0")
+            .header("ce-id", "0001")
+            .header("ce-type", "example.test")
+            .header("ce-source", "http://localhost/")
+            .header("ce-someint", "10")
+            .recv_string()
+            .await
+        {
+            Ok(r) => {
+                println!("{}", r);
+                r
+            }
+            Err(e) => panic!("Get String Failed {:?}", e),
+        };
+    }
+}

--- a/cloudevents-sdk-tide/src/server_request.rs
+++ b/cloudevents-sdk-tide/src/server_request.rs
@@ -91,7 +91,7 @@ impl<'a> MessageDeserializer for RequestDeserializer {
             Some(s) => s.as_str(),
             None => "",
         };
-        if contentheader == "application/cloudevents+json" {
+        if contentheader.starts_with("application/cloudevents+json") {
             Encoding::STRUCTURED
         } else if self
             .headers

--- a/cloudevents-sdk-tide/src/server_request.rs
+++ b/cloudevents-sdk-tide/src/server_request.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use tide::{Error, Request};
 
-/// Wrapper for [`HttpRequest`] that implements [`MessageDeserializer`] trait.
+/// Wrapper for [`Request`] that implements [`MessageDeserializer`] trait.
 pub struct RequestDeserializer {
     headers: HashMap<String, String>,
     body: Bytes,
@@ -104,7 +104,7 @@ impl<'a> MessageDeserializer for RequestDeserializer {
     }
 }
 
-/// Method to transform an incoming [`HttpRequest`] to [`Event`].
+/// Method to transform an incoming [`Request`] to [`Event`].
 pub fn request_to_event(
     headers: HashMap<String, String>,
     body: Vec<u8>,
@@ -120,7 +120,7 @@ pub fn request_to_event(
 /// This trait is sealed and cannot be implemented for types outside of this crate.
 #[allow(patterns_in_fns_without_body)]
 pub trait RequestExt: private::Sealed {
-    /// Convert this [`HttpRequest`] into an [`Event`].
+    /// Convert this [`Request`] into an [`Event`].
     fn to_event(&self, mut body: Vec<u8>) -> std::result::Result<Event, tide::Error>;
 }
 

--- a/cloudevents-sdk-tide/src/server_request.rs
+++ b/cloudevents-sdk-tide/src/server_request.rs
@@ -1,5 +1,4 @@
 use super::headers;
-use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use cloudevents::event::SpecVersion;
 use cloudevents::message::{
@@ -120,13 +119,13 @@ pub async fn request_to_event(
 ///
 /// This trait is sealed and cannot be implemented for types outside of this crate.
 #[allow(patterns_in_fns_without_body)]
-#[async_trait]
+#[tide::utils::async_trait]
 pub trait RequestExt: private::Sealed {
     /// Convert this [`Request`] into an [`Event`].
     async fn to_event(mut self) -> std::result::Result<Event, tide::Error>;
 }
 
-#[async_trait]
+#[tide::utils::async_trait]
 impl<State: Clone + Send + Sync + 'static> RequestExt for Request<State> {
     async fn to_event(mut self) -> std::result::Result<Event, tide::Error> {
         let mut headers = HashMap::new();

--- a/cloudevents-sdk-tide/src/server_response.rs
+++ b/cloudevents-sdk-tide/src/server_response.rs
@@ -86,7 +86,7 @@ impl ResponseExt for Response {
     }
 }
 
-// Sealing the ResponseBuilderExt
+// Sealing the ResponseExt
 mod private {
     pub trait Sealed {}
     impl Sealed for tide::Response {}

--- a/cloudevents-sdk-tide/src/server_response.rs
+++ b/cloudevents-sdk-tide/src/server_response.rs
@@ -74,13 +74,13 @@ pub async fn event_to_response(
 ///
 /// This trait is sealed and cannot be implemented for types outside of this crate.
 #[async_trait]
-pub trait ResponseBuilderExt: private::Sealed {
+pub trait ResponseExt: private::Sealed {
     /// Fill this [`Response`] with an [`Event`].
     async fn event(self, event: Event) -> std::result::Result<Response, tide::Error>;
 }
 
 #[async_trait]
-impl ResponseBuilderExt for Response {
+impl ResponseExt for Response {
     async fn event(self, event: Event) -> std::result::Result<Response, tide::Error> {
         event_to_response(event, self).await
     }

--- a/cloudevents-sdk-tide/src/server_response.rs
+++ b/cloudevents-sdk-tide/src/server_response.rs
@@ -1,0 +1,189 @@
+use super::headers;
+use cloudevents::event::SpecVersion;
+use cloudevents::message::{
+    BinaryDeserializer, BinarySerializer, MessageAttributeValue, Result, StructuredSerializer,
+};
+use cloudevents::Event;
+use std::str::FromStr;
+use tide::{Error, Response};
+
+/// Wrapper for [`Response`] that implements [`StructuredSerializer`] and [`BinarySerializer`].
+pub struct ResponseSerializer {
+    builder: Response,
+}
+
+impl ResponseSerializer {
+    pub fn new(builder: Response) -> ResponseSerializer {
+        ResponseSerializer { builder }
+    }
+}
+
+impl BinarySerializer<Response> for ResponseSerializer {
+    fn set_spec_version(mut self, spec_version: SpecVersion) -> Result<Self> {
+        self.builder
+            .insert_header(headers::SPEC_VERSION_HEADER.clone(), spec_version.as_str());
+        Ok(self)
+    }
+
+    fn set_attribute(mut self, name: &str, value: MessageAttributeValue) -> Result<Self> {
+        self.builder.insert_header(
+            headers::ATTRIBUTES_TO_HEADERS.get(name).unwrap().clone(),
+            value.to_string().as_str(),
+        );
+        Ok(self)
+    }
+
+    fn set_extension(mut self, name: &str, value: MessageAttributeValue) -> Result<Self> {
+        self.builder
+            .insert_header(attribute_name_to_header!(name)?, value.to_string().as_str());
+        Ok(self)
+    }
+
+    fn end_with_data(mut self, bytes: Vec<u8>) -> Result<Response> {
+        self.builder.set_body(bytes);
+        Ok(self.builder)
+    }
+
+    fn end(self) -> Result<Response> {
+        Ok(self.builder)
+    }
+}
+
+impl StructuredSerializer<Response> for ResponseSerializer {
+    fn set_structured_event(mut self, bytes: Vec<u8>) -> Result<Response> {
+        self.builder.insert_header(
+            http_types::headers::CONTENT_TYPE,
+            headers::CLOUDEVENTS_JSON_HEADER.clone(),
+        );
+        self.builder.set_body(bytes);
+        Ok(self.builder)
+    }
+}
+
+/// Method to fill an [`Response`] with an [`Event`].
+pub fn event_to_response(
+    event: Event,
+    response: Response,
+) -> std::result::Result<Response, tide::Error> {
+    BinaryDeserializer::deserialize_binary(event, ResponseSerializer::new(response))
+        .map_err(|e| Error::new(400, e))
+}
+
+/// Extension Trait for [`Response`] which acts as a wrapper for the function [`event_to_response()`].
+///
+/// This trait is sealed and cannot be implemented for types outside of this crate.
+pub trait ResponseBuilderExt: private::Sealed {
+    /// Fill this [`Response`] with an [`Event`].
+    fn event(self, event: Event) -> std::result::Result<Response, tide::Error>;
+}
+
+impl ResponseBuilderExt for Response {
+    fn event(self, event: Event) -> std::result::Result<Response, tide::Error> {
+        event_to_response(event, self)
+    }
+}
+
+// Sealing the ResponseBuilderExt
+mod private {
+    pub trait Sealed {}
+    impl Sealed for tide::Response {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloudevents::{EventBuilder, EventBuilderV10};
+    use serde_json::json;
+    use tide::Response;
+    use tide_testing::TideTestingExt;
+    #[async_std::test]
+    async fn test_response() {
+        let input = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .source("http://localhost/")
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let resp = Response::new(200).event(input).unwrap();
+
+        assert_eq!(resp.header("ce-specversion").unwrap().as_str(), "1.0");
+        assert_eq!(resp.header("ce-id").unwrap().as_str(), "0001");
+        assert_eq!(resp.header("ce-type").unwrap().as_str(), "example.test");
+        assert_eq!(
+            resp.header("ce-source").unwrap().as_str(),
+            "http://localhost/"
+        );
+        assert_eq!(resp.header("ce-someint").unwrap().as_str(), "10");
+    }
+
+    #[async_std::test]
+    async fn test_response_with_full_data() {
+        let j = json!({"hello": "world"});
+
+        let input = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .source("http://localhost/")
+            .data("application/json", j.clone())
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let resp = Response::new(200).event(input).unwrap();
+
+        assert_eq!(resp.header("ce-specversion").unwrap().as_str(), "1.0");
+        assert_eq!(resp.header("ce-id").unwrap().as_str(), "0001");
+        assert_eq!(resp.header("ce-type").unwrap().as_str(), "example.test");
+        assert_eq!(
+            resp.header("ce-source").unwrap().as_str(),
+            "http://localhost/"
+        );
+        assert_eq!(
+            resp.header("content-type").unwrap().as_str(),
+            "application/json"
+        );
+        assert_eq!(resp.header("ce-someint").unwrap().as_str(), "10");
+    }
+
+    #[async_std::test]
+    async fn test_response_in_service() {
+        let mut app = tide::new();
+        app.at("/").get(|_| async move {
+            let j = json!({"hello":"world"});
+            let input = EventBuilderV10::new()
+                .id("0001")
+                .ty("example.test")
+                .source("http://localhost/")
+                .data("application/json", j.clone())
+                .extension("someint", "10")
+                .build()
+                .unwrap();
+
+            let resp = Response::new(200).event(input).unwrap();
+            Ok(resp)
+        });
+
+        match app.get("/").recv_string().await {
+            Ok(r) => {
+                println!("test_response_in_service:{}", r);
+                r
+            }
+            Err(e) => panic!("Get String Failed {:?}", e),
+        };
+    }
+
+    // use async_std::stream::Stream;
+    // use bytes::{Bytes, BytesMut};
+    // pub async fn load_stream<S>(mut stream: S) -> Result<Bytes, Error>
+    // where
+    //     S: Stream<Item = Result<Bytes, Error>> + Unpin,
+    // {
+    //     let mut data = BytesMut::new();
+    //     while let Some(item) = stream.next().await {
+    //         data.extend_from_slice(&item?);
+    //     }
+    //     Ok(data.freeze())
+    // }
+}

--- a/cloudevents-sdk-tide/src/server_response.rs
+++ b/cloudevents-sdk-tide/src/server_response.rs
@@ -1,5 +1,4 @@
 use super::headers;
-use async_trait::async_trait;
 use cloudevents::event::SpecVersion;
 use cloudevents::message::{
     BinaryDeserializer, BinarySerializer, MessageAttributeValue, Result, StructuredSerializer,
@@ -73,13 +72,13 @@ pub async fn event_to_response(
 /// Extension Trait for [`Response`] which acts as a wrapper for the function [`event_to_response()`].
 ///
 /// This trait is sealed and cannot be implemented for types outside of this crate.
-#[async_trait]
+#[tide::utils::async_trait]
 pub trait ResponseExt: private::Sealed {
     /// Fill this [`Response`] with an [`Event`].
     async fn event(self, event: Event) -> std::result::Result<Response, tide::Error>;
 }
 
-#[async_trait]
+#[tide::utils::async_trait]
 impl ResponseExt for Response {
     async fn event(self, event: Event) -> std::result::Result<Response, tide::Error> {
         event_to_response(event, self).await

--- a/cloudevents-sdk-warp/src/filter.rs
+++ b/cloudevents-sdk-warp/src/filter.rs
@@ -42,13 +42,11 @@ async fn create_event(headers: HeaderMap, body: bytes::Bytes) -> Result<Event, R
 #[cfg(test)]
 mod tests {
     use super::to_event;
-    use url::Url;
     use warp::test;
 
     use chrono::Utc;
     use cloudevents::{EventBuilder, EventBuilderV10};
     use serde_json::json;
-    use std::str::FromStr;
 
     #[tokio::test]
     async fn test_request() {
@@ -110,7 +108,7 @@ mod tests {
         let expected = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .time(time)
             .data("application/json", j.to_string().into_bytes())
             .extension("someint", "10")

--- a/cloudevents-sdk-warp/src/lib.rs
+++ b/cloudevents-sdk-warp/src/lib.rs
@@ -31,7 +31,7 @@
 //!     let routes = warp::any().map(|| {
 //!         let event = EventBuilderV10::new()
 //!             .id("1")
-//!             .source(url::Url::parse("url://example_response/").unwrap())
+//!             .source("url://example_response/")
 //!             .ty("example.ce")
 //!             .data(
 //!                 mime::APPLICATION_JSON.to_string(),

--- a/cloudevents-sdk-warp/src/reply.rs
+++ b/cloudevents-sdk-warp/src/reply.rs
@@ -31,15 +31,13 @@ mod tests {
 
     use cloudevents::{EventBuilder, EventBuilderV10};
     use serde_json::json;
-    use std::str::FromStr;
-    use url::Url;
 
     #[test]
     fn test_response() {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost/").unwrap())
+            .source("http://localhost/")
             .extension("someint", "10")
             .build()
             .unwrap();
@@ -79,7 +77,7 @@ mod tests {
         let input = EventBuilderV10::new()
             .id("0001")
             .ty("example.test")
-            .source(Url::from_str("http://localhost").unwrap())
+            .source("http://localhost")
             .data("application/json", j.clone())
             .extension("someint", "10")
             .build()
@@ -105,7 +103,7 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
-            "http://localhost/"
+            "http://localhost"
         );
         assert_eq!(
             resp.headers()

--- a/example-projects/tide-example/Cargo.toml
+++ b/example-projects/tide-example/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tide-example"
+version = "0.1.0"
+authors = ["Anthony Whalley <anton@venshare.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cloudevents-sdk = { path = "../.." }
+cloudevents-sdk-tide = { path = "../../cloudevents-sdk-tide" }
+tide = { version = "0.16" }
+async-std = { version = "1", features = ["attributes"] }
+
+[workspace]

--- a/example-projects/tide-example/Cargo.toml
+++ b/example-projects/tide-example/Cargo.toml
@@ -11,5 +11,9 @@ cloudevents-sdk = { path = "../.." }
 cloudevents-sdk-tide = { path = "../../cloudevents-sdk-tide" }
 tide = { version = "0.16" }
 async-std = { version = "1", features = ["attributes"] }
+tide-websockets = "0.3.0"
+futures-util = "0.3.8"
+serde_json = "1.0.64"
+chrono = { version = "^0.4", features = ["serde"] }
 
 [workspace]

--- a/example-projects/tide-example/public/index.html
+++ b/example-projects/tide-example/public/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>CloudEvent UI</title>
+  <meta charset="utf-8">
+  <meta name="author" content="Anton Whalley">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <style>
+      textarea {
+        width: 500px;
+        height: 300px;
+        }
+
+  </style>
+</head>
+<body>
+    CloudEvent UI
+    <br />
+    <textarea id="msg">
+        {
+            "specversion" : "1.0",
+            "type" : "com.example.someevent",
+            "source" : "/mycontext",
+            "id" : "A234-1234-1234",
+            "time" : "2018-04-05T17:31:00Z",
+            "comexampleextension1" : "value",
+            "comexampleothervalue" : 5,
+            "datacontenttype" : "text/xml",
+            "data" : "<much wow=\"xml\"/>"
+        }
+    </textarea>
+    <br/>
+    <button onclick="send()">Send</button>
+    <div>Responses:</div>
+    <div id="responses"></div>
+<script>
+let io;
+document.addEventListener("DOMContentLoaded", function() {
+    // connect to ws
+    const ws_url = `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}${window.location.pathname}`;
+    io = new WebSocket( ws_url, ["cloudevents.json", "cloudevents.avro"] );
+    io.onmessage = function (event) {
+        let msg = document.getElementById("responses").innerHTML;
+        msg += JSON.stringify(event.data);
+        console.log(event.data);
+        document.getElementById("responses").innerHTML = msg;
+    }
+} );
+
+function send() {
+    let msg = document.getElementById("msg").value;
+    console.log(msg);
+    io.send(msg);
+}
+
+
+
+</script>
+</body>
+</html>

--- a/example-projects/tide-example/src/main.rs
+++ b/example-projects/tide-example/src/main.rs
@@ -15,9 +15,8 @@ use tide::{Response, Request, Body};
      )
  }
 
- pub async fn post(mut req: Request<()>) -> tide::Result {
-    let body = req.body_bytes().await?;
-     let evtresp: Event = req.to_event(body.to_vec()).await?;
+ pub async fn post(req: Request<()>) -> tide::Result {
+     let evtresp: Event = req.to_event().await?;
      let response = Response::builder(200)
      .body(Body::from_json(&evtresp)?)
      .build();

--- a/example-projects/tide-example/src/main.rs
+++ b/example-projects/tide-example/src/main.rs
@@ -1,0 +1,39 @@
+use cloudevents::{EventBuilder, EventBuilderV10, Event};
+use cloudevents_sdk_tide::*;
+use tide::{Response, Request, Body};
+ 
+ pub async fn get(_req: Request<()>) -> tide::Result {
+     Ok(Response::new(200).event(
+             EventBuilderV10::new()
+                 .id("0001")
+                 .ty("example.test")
+                 .source("http://localhost/")
+                 .data("text/xml", "<xml data=\"hello\" />".as_bytes().to_vec())
+                 .build()
+                 .expect("No error while building the event"),
+         )?
+     )
+ }
+
+ pub async fn post(mut req: Request<()>) -> tide::Result {
+    let body = req.body_bytes().await?;
+     let evtresp: Event = req.to_event(body.to_vec())?;
+     let response = Response::builder(200)
+     .body(Body::from_json(&evtresp)?)
+     .build();
+     Ok(response)
+ }
+
+ //Test post with 
+ // curl -H "Content-Type:text/plain" -H "ce-specversion:1.0" -H "ce-id:0001" -H "ce-source:http://localhost"  -H "ce-type:example.test" -d "hello" http://127.0.0.1:8080/ 
+ #[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
+    let mut index = app.at("/");
+    index.get(get);
+    index.post(post);
+
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}

--- a/example-projects/tide-example/src/main.rs
+++ b/example-projects/tide-example/src/main.rs
@@ -1,38 +1,73 @@
-use cloudevents::{EventBuilder, EventBuilderV10, Event};
+use chrono::Utc;
+use cloudevents::{Event, EventBuilder, EventBuilderV10};
 use cloudevents_sdk_tide::*;
-use tide::{Response, Request, Body};
- 
- pub async fn get(_req: Request<()>) -> tide::Result {
-     Ok(Response::new(200).event(
-             EventBuilderV10::new()
-                 .id("0001")
-                 .ty("example.test")
-                 .source("http://localhost/")
-                 .data("text/xml", "<xml data=\"hello\" />".as_bytes().to_vec())
-                 .build()
-                 .expect("No error while building the event"),
-         ).await?
-     )
- }
+use futures_util::StreamExt;
+use serde_json::json;
+use tide::log;
+use tide::{Body, Request, Response};
+use tide_websockets::{Message, WebSocket, WebSocketConnection};
 
- pub async fn post(req: Request<()>) -> tide::Result {
-     let evtresp: Event = req.to_event().await?;
-     let response = Response::builder(200)
-     .body(Body::from_json(&evtresp)?)
-     .build();
-     Ok(response)
- }
+pub async fn get(_req: Request<()>) -> tide::Result {
+    Ok(Response::new(200)
+        .event(
+            EventBuilderV10::new()
+                .id("0001")
+                .ty("example.test")
+                .source("http://localhost/")
+                .data("text/xml", "<xml data=\"hello\" />".as_bytes().to_vec())
+                .build()
+                .expect("No error while building the event"),
+        )
+        .await?)
+}
 
- //Test post with 
- // curl -H "Content-Type:text/plain" -H "ce-specversion:1.0" -H "ce-id:0001" -H "ce-source:http://localhost"  -H "ce-type:example.test" -d "hello" http://127.0.0.1:8080/ 
- #[async_std::main]
+pub async fn post(req: Request<()>) -> tide::Result {
+    let evtresp: Event = req.to_event().await?;
+    let response = Response::builder(200)
+        .body(Body::from_json(&evtresp)?)
+        .build();
+    Ok(response)
+}
+
+//Test post with
+// curl -H "Content-Type:text/plain" -H "ce-specversion:1.0" -H "ce-id:0001" -H "ce-source:http://localhost"  -H "ce-type:example.test" -d "hello" http://127.0.0.1:8080/
+#[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
+
     let mut app = tide::new();
     let mut index = app.at("/");
     index.get(get);
     index.post(post);
 
+    app.at("/socket")
+        .with(
+            WebSocket::new(
+                |_req: Request<_>, mut wsc: WebSocketConnection| async move {
+                    while let Some(Ok(Message::Text(message))) = wsc.next().await {
+                        let time = Utc::now();
+                        let msg = json!({ "hello":"world" });
+                        let v: Event = serde_json::from_str(&message).unwrap();
+                        println!("{:?}", v);
+                        let resp = EventBuilderV10::new()
+                            .id("0001")
+                            .ty("example.test")
+                            .source("http://localhost/")
+                            .time(time)
+                            .data("application/cloudevents+json", msg)
+                            .build()
+                            .unwrap();
+                        wsc.send_json(&resp).await?;
+                    }
+
+                    Ok(())
+                },
+            )
+            .with_protocols(&["cloudevents.json"]),
+        )
+        .get(|_| async { Ok(Body::from_file("./public/index.html").await?) });
+
+    log::info!("Socket UI: http://127.0.0.1:8080/socket");
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/example-projects/tide-example/src/main.rs
+++ b/example-projects/tide-example/src/main.rs
@@ -11,13 +11,13 @@ use tide::{Response, Request, Body};
                  .data("text/xml", "<xml data=\"hello\" />".as_bytes().to_vec())
                  .build()
                  .expect("No error while building the event"),
-         )?
+         ).await?
      )
  }
 
  pub async fn post(mut req: Request<()>) -> tide::Result {
     let body = req.body_bytes().await?;
-     let evtresp: Event = req.to_event(body.to_vec())?;
+     let evtresp: Event = req.to_event(body.to_vec()).await?;
      let response = Response::builder(200)
      .body(Body::from_json(&evtresp)?)
      .build();

--- a/src/event/builder.rs
+++ b/src/event/builder.rs
@@ -44,7 +44,7 @@ pub enum Error {
         source: chrono::ParseError,
     },
     #[snafu(display(
-        "Error while setting attribute '{}' with uri/uriref type: {}",
+        "Error while setting attribute '{}' with uri type: {}",
         attribute_name,
         source
     ))]
@@ -52,4 +52,9 @@ pub enum Error {
         attribute_name: &'static str,
         source: url::ParseError,
     },
+    #[snafu(display(
+        "Invalid value setting attribute '{}' with uriref type",
+        attribute_name,
+    ))]
+    InvalidUriRefError { attribute_name: &'static str },
 }

--- a/src/event/v03/attributes.rs
+++ b/src/event/v03/attributes.rs
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(
             (
                 "source",
-                AttributeValue::URIRef(&Url::parse("https://example.net").unwrap())
+                AttributeValue::URIRef(&"https://example.net".to_string())
             ),
             b.next().unwrap()
         );

--- a/src/event/v03/builder.rs
+++ b/src/event/v03/builder.rs
@@ -31,7 +31,14 @@ impl EventBuilder {
     }
 
     pub fn source(mut self, source: impl Into<String>) -> Self {
-        self.source = Some(source.into());
+        let source = source.into();
+        if source.is_empty() {
+            self.error = Some(EventBuilderError::InvalidUriRefError {
+                attribute_name: "source",
+            });
+        } else {
+            self.source = Some(source);
+        }
         self
     }
 

--- a/src/event/v10/attributes.rs
+++ b/src/event/v10/attributes.rs
@@ -228,7 +228,7 @@ mod tests {
         let a = Attributes {
             id: String::from("1"),
             ty: String::from("someType"),
-            source: Url::parse("https://example.net").unwrap(),
+            source: "https://example.net".into(),
             datacontenttype: None,
             dataschema: None,
             subject: None,
@@ -252,7 +252,7 @@ mod tests {
         assert_eq!(
             (
                 "source",
-                AttributeValue::URIRef(&Url::parse("https://example.net").unwrap())
+                AttributeValue::URIRef(&"https://example.net".to_string())
             ),
             b.next().unwrap()
         );

--- a/src/event/v10/builder.rs
+++ b/src/event/v10/builder.rs
@@ -31,7 +31,14 @@ impl EventBuilder {
     }
 
     pub fn source(mut self, source: impl Into<String>) -> Self {
-        self.source = Some(source.into());
+        let source = source.into();
+        if source.is_empty() {
+            self.error = Some(EventBuilderError::InvalidUriRefError {
+                attribute_name: "source",
+            });
+        } else {
+            self.source = Some(source);
+        }
         self
     }
 

--- a/tests/builder_v03.rs
+++ b/tests/builder_v03.rs
@@ -12,7 +12,7 @@ use url::Url;
 #[test]
 fn build_event() {
     let id = "aaa";
-    let source = Url::parse("http://localhost:8080").unwrap();
+    let source = "http://localhost:8080";
     let ty = "bbb";
     let subject = "francesco";
     let time: DateTime<Utc> = Utc::now();
@@ -53,6 +53,16 @@ fn build_event() {
 }
 
 #[test]
+fn source_valid_relative_url() {
+    let res = EventBuilderV03::new()
+        .id("id1")
+        .source("/source") // relative URL
+        .ty("type")
+        .build();
+    assert_match_pattern!(res, Ok(_));
+}
+
+#[test]
 fn build_missing_id() {
     let res = EventBuilderV03::new()
         .source("http://localhost:8080")
@@ -70,9 +80,8 @@ fn source_invalid_url() {
     let res = EventBuilderV03::new().source("").build();
     assert_match_pattern!(
         res,
-        Err(EventBuilderError::ParseUrlError {
+        Err(EventBuilderError::InvalidUriRefError {
             attribute_name: "source",
-            ..
         })
     );
 }

--- a/tests/builder_v10.rs
+++ b/tests/builder_v10.rs
@@ -12,7 +12,7 @@ use url::Url;
 #[test]
 fn build_event() {
     let id = "aaa";
-    let source = Url::parse("http://localhost:8080").unwrap();
+    let source = "http://localhost:8080";
     let ty = "bbb";
     let subject = "francesco";
     let time: DateTime<Utc> = Utc::now();
@@ -53,6 +53,16 @@ fn build_event() {
 }
 
 #[test]
+fn source_valid_relative_url() {
+    let res = EventBuilderV10::new()
+        .id("id1")
+        .source("/source") // relative URL
+        .ty("type")
+        .build();
+    assert_match_pattern!(res, Ok(_));
+}
+
+#[test]
 fn build_missing_id() {
     let res = EventBuilderV10::new()
         .source("http://localhost:8080")
@@ -70,9 +80,8 @@ fn source_invalid_url() {
     let res = EventBuilderV10::new().source("").build();
     assert_match_pattern!(
         res,
-        Err(EventBuilderError::ParseUrlError {
+        Err(EventBuilderError::InvalidUriRefError {
             attribute_name: "source",
-            ..
         })
     );
 }

--- a/tests/test_data/v03.rs
+++ b/tests/test_data/v03.rs
@@ -7,7 +7,7 @@ use url::Url;
 pub fn minimal() -> Event {
     EventBuilderV03::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .build()
         .unwrap()
@@ -29,7 +29,7 @@ pub fn full_no_data() -> Event {
 
     EventBuilderV03::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -65,7 +65,7 @@ pub fn full_json_data() -> Event {
 
     EventBuilderV03::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -131,7 +131,7 @@ pub fn full_xml_string_data() -> Event {
 
     EventBuilderV03::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -150,7 +150,7 @@ pub fn full_xml_binary_data() -> Event {
 
     EventBuilderV03::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())

--- a/tests/test_data/v10.rs
+++ b/tests/test_data/v10.rs
@@ -6,7 +6,7 @@ use url::Url;
 pub fn minimal() -> Event {
     EventBuilderV10::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .build()
         .unwrap()
@@ -28,7 +28,7 @@ pub fn full_no_data() -> Event {
 
     EventBuilderV10::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -64,7 +64,7 @@ pub fn full_json_data() -> Event {
 
     EventBuilderV10::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -129,7 +129,7 @@ pub fn full_xml_string_data() -> Event {
 
     EventBuilderV10::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())
@@ -148,7 +148,7 @@ pub fn full_xml_binary_data() -> Event {
 
     EventBuilderV10::new()
         .id(id())
-        .source(Url::parse(source().as_ref()).unwrap())
+        .source(source())
         .ty(ty())
         .subject(subject())
         .time(time())


### PR DESCRIPTION
Signed-off-by: Anthony Whalley <anton@venshare.com>
This PR adds support for tide, the server framework of http-rs. 
https://github.com/http-rs/tide 
It uses 0.3.1 of the cloud events library.
The code follows the actix implementation ~~but avoids using the async-trait library as it wasn't clear what the benefit of that would be and async-trait comes with a warning on performance.~~
I'd appreciate any feedback and hope someone can spare some time to land this.   
