### PR TITLE
surf support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ members = [
   "cloudevents-sdk-actix-web",
   "cloudevents-sdk-reqwest",
   "cloudevents-sdk-rdkafka",
-  "cloudevents-sdk-warp"
+  "cloudevents-sdk-warp",
+  "cloudevents-sdk-surf"
 ]
 exclude = [
   "example-projects/actix-web-example",

--- a/cloudevents-sdk-surf/Cargo.toml
+++ b/cloudevents-sdk-surf/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "cloudevents-sdk-surf"
+authors = ["Anthony Whalley <anton@venshare.com>"]
+edition = "2018"
+version = "0.3.1"
+license-file = "../LICENSE"
+description = "CloudEvents official Rust SDK - Surf integration"
+documentation = "https://docs.rs/cloudevents-sdk-surf"
+repository = "https://github.com/cloudevents/sdk-rust"
+readme = "README.md"
+categories = ["web-programming", "encoding", "web-programming::http-client"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "^0.1.33"
+bytes = "1.0.1"
+cloudevents-sdk = { version = "0.3.0", path = ".." }
+lazy_static = "1.4.0"
+surf = "2.2.0"
+
+[dev-dependencies]
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "^1.0"
+chrono = { version = "^0.4", features = ["serde"] }
+version-sync = "^0.9"
+async-std = { version = "1", features = ["attributes"] }
+mockito = "0.25.1"

--- a/cloudevents-sdk-surf/src/client_request.rs
+++ b/cloudevents-sdk-surf/src/client_request.rs
@@ -1,0 +1,194 @@
+use super::headers;
+use async_trait::async_trait;
+use cloudevents::event::SpecVersion;
+use cloudevents::message::{
+    BinaryDeserializer, BinarySerializer, MessageAttributeValue, Result, StructuredSerializer,
+};
+use cloudevents::Event;
+use std::str::FromStr;
+use surf::{Error, Request};
+
+/// Wrapper for [`Request`] that implements [`StructuredSerializer`] and [`BinarySerializer`].
+pub struct RequestSerializer {
+    builder: Request,
+}
+
+impl RequestSerializer {
+    pub fn new(builder: Request) -> RequestSerializer {
+        RequestSerializer { builder }
+    }
+}
+
+impl BinarySerializer<Request> for RequestSerializer {
+    fn set_spec_version(mut self, spec_version: SpecVersion) -> Result<Self> {
+        self.builder
+            .insert_header(headers::SPEC_VERSION_HEADER.clone(), spec_version.as_str());
+        Ok(self)
+    }
+
+    fn set_attribute(mut self, name: &str, value: MessageAttributeValue) -> Result<Self> {
+        self.builder.insert_header(
+            headers::ATTRIBUTES_TO_HEADERS.get(name).unwrap().clone(),
+            value.to_string().as_str(),
+        );
+        Ok(self)
+    }
+
+    fn set_extension(mut self, name: &str, value: MessageAttributeValue) -> Result<Self> {
+        self.builder
+            .insert_header(attribute_name_to_header!(name)?, value.to_string().as_str());
+        Ok(self)
+    }
+
+    fn end_with_data(mut self, bytes: Vec<u8>) -> Result<Request> {
+        self.builder.set_body(bytes);
+        Ok(self.builder)
+    }
+
+    fn end(self) -> Result<Request> {
+        Ok(self.builder)
+    }
+}
+
+impl StructuredSerializer<Request> for RequestSerializer {
+    fn set_structured_event(mut self, bytes: Vec<u8>) -> Result<Request> {
+        self.builder.insert_header(
+            surf::http::headers::CONTENT_TYPE,
+            headers::CLOUDEVENTS_JSON_HEADER.clone(),
+        );
+        self.builder.set_body(bytes);
+        Ok(self.builder)
+    }
+}
+
+/// Method to fill an [`Request`] with an [`Event`].
+pub async fn event_to_request(
+    event: Event,
+    request: Request,
+) -> std::result::Result<Request, surf::Error> {
+    BinaryDeserializer::deserialize_binary(event, RequestSerializer::new(request))
+        .map_err(|e| Error::new(400, e))
+}
+
+/// Extension Trait for [`Request`] which acts as a wrapper for the function [`event_to_Request()`].
+///
+/// This trait is sealed and cannot be implemented for types outside of this crate.
+#[async_trait]
+pub trait RequestExt: private::Sealed {
+    /// Fill this [`Request`] with an [`Event`].
+    async fn event(self, event: Event) -> std::result::Result<Request, surf::Error>;
+}
+
+#[async_trait]
+impl RequestExt for Request {
+    async fn event(self, event: Event) -> std::result::Result<Request, surf::Error> {
+        event_to_request(event, self).await
+    }
+}
+
+
+// Sealing the RequestExt
+mod private {
+    pub trait Sealed {}
+    impl Sealed for surf::Request {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloudevents::message::StructuredDeserializer;
+    use cloudevents::{EventBuilder, EventBuilderV10};
+    use mockito::{mock, Matcher};
+    use serde_json::json;
+    use surf::http;
+    use surf::Url;
+
+    #[async_std::test]
+    async fn test_request() {
+        let url = mockito::server_url();
+        let m = mock("POST", "/")
+            .with_header("content-type", "application/octet-stream")
+            .match_header("ce-specversion", "1.0")
+            .match_header("ce-id", "0001")
+            .match_header("ce-type", "example.test")
+            .match_header("ce-source", "http://localhost/")
+            .match_header("ce-someint", "10")
+            .match_body(Matcher::Missing)
+            .create();
+
+        let input = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .source("http://localhost/")
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let req = Request::new(http::Method::Post, Url::parse(url.as_str()).unwrap());
+        let evt = req.event(input).await.unwrap();
+        let client = surf::Client::new();
+        client.send(evt).await.unwrap();
+
+        m.assert();
+    }
+
+    #[async_std::test]
+    async fn test_request_with_full_data() {
+        let j = json!({"hello": "world"});
+
+        let url = mockito::server_url();
+        let m = mock("POST", "/")
+            .match_header("ce-specversion", "1.0")
+            .match_header("ce-id", "0001")
+            .match_header("ce-type", "example.test")
+            .match_header("ce-source", "http://localhost/")
+            .match_header("content-type", "application/json")
+            .match_header("ce-someint", "10")
+            .match_body(Matcher::Exact(j.to_string()))
+            .create();
+
+        let input = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .source("http://localhost/")
+            .data("application/json", j.clone())
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let req = Request::new(http::Method::Post, Url::parse(url.as_str()).unwrap());
+        let evt = req.event(input).await.unwrap();
+        let client = surf::Client::new();
+        client.send(evt).await.unwrap();
+
+        m.assert();
+    }
+
+    #[async_std::test]
+    async fn test_structured_request_with_full_data() {
+        let j = json!({"hello": "world"});
+
+        let input = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .source("http://localhost")
+            .data("application/json", j.clone())
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let url = mockito::server_url();
+        let m = mock("POST", "/")
+            .match_header("content-type", "application/cloudevents+json")
+            .match_body(Matcher::Exact(serde_json::to_string(&input).unwrap()))
+            .create();
+
+        let req = Request::new(http::Method::Post, Url::parse(url.as_str()).unwrap());
+        let client = surf::Client::new();
+        let evt =
+            StructuredDeserializer::deserialize_structured(input, RequestSerializer::new(req));
+        client.send(evt.unwrap()).await.unwrap();
+
+        m.assert();
+    }
+}

--- a/cloudevents-sdk-surf/src/client_response.rs
+++ b/cloudevents-sdk-surf/src/client_response.rs
@@ -1,0 +1,257 @@
+use super::headers;
+use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
+use cloudevents::event::SpecVersion;
+use cloudevents::message::{
+    BinaryDeserializer, BinarySerializer, Encoding, MessageAttributeValue, MessageDeserializer,
+    Result, StructuredDeserializer, StructuredSerializer,
+};
+use cloudevents::{message, Event};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use surf::{Error, Response};
+
+/// Wrapper for [`Response`] that implements [`MessageDeserializer`] trait.
+pub struct ResponseDeserializer {
+    headers: HashMap<String, String>,
+    body: Bytes,
+}
+
+impl ResponseDeserializer {
+    pub fn new(headers: HashMap<String, String>, body: Bytes) -> ResponseDeserializer {
+        ResponseDeserializer { headers, body }
+    }
+}
+
+impl<'a> BinaryDeserializer for ResponseDeserializer {
+    fn deserialize_binary<R: Sized, V: BinarySerializer<R>>(self, mut visitor: V) -> Result<R> {
+        if self.encoding() != Encoding::BINARY {
+            return Err(message::Error::WrongEncoding {});
+        }
+
+        let versionheader = match self.headers.get("ce-specversion") {
+            Some(s) => s.as_str(),
+            None => "",
+        };
+        let spec_version = SpecVersion::try_from(versionheader)?;
+
+        visitor = visitor.set_spec_version(spec_version.clone())?;
+
+        let attributes = spec_version.attribute_names();
+
+        for (k, _) in self.headers.iter().filter(|&(k, _)| {
+            headers::SPEC_VERSION_HEADER.ne(k.as_str()) && k.as_str().starts_with("ce-")
+        }) {
+            let name = &k.as_str()["ce-".len()..];
+
+            if attributes.contains(&name) {
+                visitor = visitor.set_attribute(
+                    name,
+                    MessageAttributeValue::String(String::from(header_to_str!(self
+                        .headers
+                        .get(k)))),
+                )?
+            } else {
+                visitor = visitor.set_extension(
+                    name,
+                    MessageAttributeValue::String(String::from(header_to_str!(self
+                        .headers
+                        .get(k)))),
+                )?
+            }
+        }
+
+        if !self.body.is_empty() {
+            // surf defaults the content-type header but we are ignoring it if the body is empty
+            if let Some(hv) = self.headers.get("content-type") {
+                println!("content-type: {}", hv);
+                visitor = visitor.set_attribute(
+                    "datacontenttype",
+                    MessageAttributeValue::String(String::from(hv.as_str())),
+                )?
+            }
+            visitor.end_with_data(self.body.to_vec())
+        } else {
+            visitor.end()
+        }
+    }
+}
+
+impl<'a> StructuredDeserializer for ResponseDeserializer {
+    fn deserialize_structured<R: Sized, V: StructuredSerializer<R>>(self, visitor: V) -> Result<R> {
+        if self.encoding() != Encoding::STRUCTURED {
+            return Err(message::Error::WrongEncoding {});
+        }
+        visitor.set_structured_event(self.body.to_vec())
+    }
+}
+
+impl<'a> MessageDeserializer for ResponseDeserializer {
+    fn encoding(&self) -> Encoding {
+        let contentheader = match self.headers.get("content-type") {
+            Some(s) => s.as_str(),
+            None => "",
+        };
+        if contentheader.starts_with("application/cloudevents+json") {
+            Encoding::STRUCTURED
+        } else if self
+            .headers
+            .get(super::headers::SPEC_VERSION_HEADER.as_str())
+            .is_some()
+        {
+            Encoding::BINARY
+        } else {
+            Encoding::UNKNOWN
+        }
+    }
+}
+
+/// Method to transform an incoming [`Response`] to [`Event`].
+pub async fn response_to_event(
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+) -> std::result::Result<Event, surf::Error> {
+    let mut bytes = BytesMut::with_capacity(body.len());
+    bytes.extend_from_slice(body.as_slice());
+    MessageDeserializer::into_event(ResponseDeserializer::new(headers, bytes.freeze()))
+        .map_err(|e| Error::new(400, e))
+}
+
+/// Extention Trait for [`Response`] which acts as a wrapper for the function [`Response_to_event()`].
+///
+/// This trait is sealed and cannot be implemented for types outside of this crate.
+#[allow(patterns_in_fns_without_body)]
+#[async_trait]
+pub trait ResponseExt: private::Sealed {
+    /// Convert this [`Response`] into an [`Event`].
+    async fn to_event(mut self) -> std::result::Result<Event, surf::Error>;
+}
+
+#[async_trait]
+impl ResponseExt for Response {
+    async fn to_event(mut self) -> std::result::Result<Event, surf::Error> {
+        let mut headers = HashMap::new();
+        for (n, v) in self.iter() {
+            headers.insert(String::from(n.as_str()), String::from(v.as_str()));
+        }
+        let body = self.body_bytes().await?;
+        response_to_event(headers, body).await
+    }
+}
+
+mod private {
+    // Sealing the ResponseExt
+    pub trait Sealed {}
+    impl Sealed for surf::Response {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use cloudevents::{EventBuilder, EventBuilderV10};
+    use mockito::{mock};
+    use serde_json::json;
+    
+
+    #[async_std::test]
+    async fn test_response() {
+        let time = Utc::now();
+        let url = mockito::server_url();
+        let _m = mock("GET", "/")
+            .with_status(200)
+            .with_header("ce-specversion", "1.0")
+            .with_header("ce-id", "0001")
+            .with_header("ce-type", "example.test")
+            .with_header("ce-source", "http://localhost")
+            .with_header("ce-someint", "10")
+            .with_header("ce-time", &time.to_rfc3339())
+            .create();
+
+        let expected = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            .time(time)
+            .source("http://localhost")
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let client = surf::Client::new();
+        let res = client.get(&url).send().await.unwrap();
+        let evt = res.to_event().await.unwrap();
+
+        assert_eq!(expected, evt);
+    }
+
+    #[async_std::test]
+    async fn test_response_with_full_data() {
+        let time = Utc::now();
+        let j = json!({"hello": "world"});
+
+        let url = mockito::server_url();
+        let _m = mock("GET", "/")
+            .with_status(200)
+            .with_header("ce-specversion", "1.0")
+            .with_header("ce-id", "0001")
+            .with_header("ce-type", "example.test")
+            .with_header("ce-source", "http://localhost/")
+            .with_header("content-type", "application/json")
+            .with_header("ce-someint", "10")
+            .with_header("ce-time", &time.to_rfc3339())
+            .with_body(j.to_string())
+            .create();
+
+        let expected = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            //TODO this is required now because the message deserializer implictly set default values
+            // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
+            .time(time)
+            .source("http://localhost/")
+            .data("application/json", j.to_string().into_bytes())
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+            let client = surf::Client::new();
+            let res = client.get(&url).send().await.unwrap();
+            let evt = res.to_event().await.unwrap();
+
+        assert_eq!(expected, evt);
+    }
+
+    #[async_std::test]
+    async fn test_structured_response_with_full_data() {
+        let time = Utc::now();
+
+        let j = json!({"hello": "world"});
+        let expected = EventBuilderV10::new()
+            .id("0001")
+            .ty("example.test")
+            //TODO this is required now because the message deserializer implictly set default values
+            // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
+            .time(time)
+            .source("http://localhost")
+            .data("application/json", j.clone())
+            .extension("someint", "10")
+            .build()
+            .unwrap();
+
+        let url = mockito::server_url();
+        let _m = mock("GET", "/")
+            .with_status(200)
+            .with_header(
+                "content-type",
+                "application/cloudevents+json; charset=utf-8",
+            )
+            .with_body(serde_json::to_string(&expected).unwrap())
+            .create();
+
+            let client = surf::Client::new();
+            let res = client.get(&url).send().await.unwrap();
+            let evt = res.to_event().await.unwrap();
+
+        assert_eq!(expected, evt);
+    }
+}

--- a/cloudevents-sdk-surf/src/headers.rs
+++ b/cloudevents-sdk-surf/src/headers.rs
@@ -1,0 +1,49 @@
+use cloudevents::event::SpecVersion;
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use std::str::FromStr;
+use surf::http::headers::{HeaderName, HeaderValue};
+
+macro_rules! header_to_str {
+    ($header_value:expr) => {
+        $header_value.unwrap().as_str()
+    };
+}
+
+macro_rules! str_name_to_header {
+    ($attribute:expr) => {
+        surf::http::headers::HeaderName::from_str($attribute).map_err(|e| {
+            cloudevents::message::Error::Other {
+                source: Box::new(std::io::Error::new(std::io::ErrorKind::Other, e)),
+            }
+        })
+    };
+}
+
+macro_rules! attribute_name_to_header {
+    ($attribute:expr) => {
+        str_name_to_header!(&["ce-", $attribute].concat())
+    };
+}
+
+fn attributes_to_headers(
+    it: impl Iterator<Item = &'static str>,
+) -> HashMap<&'static str, HeaderName> {
+    it.map(|s| {
+        if s == "datacontenttype" {
+            (s, surf::http::headers::CONTENT_TYPE)
+        } else {
+            (s, attribute_name_to_header!(s).unwrap())
+        }
+    })
+    .collect()
+}
+
+lazy_static! {
+    pub(crate) static ref ATTRIBUTES_TO_HEADERS: HashMap<&'static str, HeaderName> =
+        attributes_to_headers(SpecVersion::all_attribute_names());
+    pub(crate) static ref SPEC_VERSION_HEADER: HeaderName =
+        HeaderName::from_str("ce-specversion").unwrap();
+    pub(crate) static ref CLOUDEVENTS_JSON_HEADER: HeaderValue =
+        HeaderValue::from_str("application/cloudevents+json").unwrap();
+}

--- a/cloudevents-sdk-surf/src/lib.rs
+++ b/cloudevents-sdk-surf/src/lib.rs
@@ -1,0 +1,46 @@
+//! This crate integrates the [cloudevents-sdk](https://docs.rs/cloudevents-sdk) with [surf](https://docs.rs/surf/) to easily send and receive CloudEvents.
+//!
+//! ```
+//! use cloudevents_sdk_surf::{RequestExt, ResponseExt};
+//! use cloudevents::{EventBuilderV10, EventBuilder};
+//! use serde_json::json;
+//! use surf::{http, Url, Request};
+//! 
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = surf::Client::new();
+//!
+//! // Prepare the event to send
+//! let event_to_send = EventBuilderV10::new()
+//!     .id("0001")
+//!     .ty("example.test")
+//!     .source("http://localhost/")
+//!     .data("application/json", json!({"hello": "world"}))
+//!     .build()?;
+//!
+//! // Send request
+//! let req = Request::new(http::Method::Post, Url::parse("http://localhost/").unwrap());
+//! let evt = req.event(event_to_send).await.unwrap();
+//! let client = surf::Client::new();
+//! let response = client.send(evt).await.unwrap();
+//! let received_event = response
+//!   .to_event().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Check out the [cloudevents-sdk](https://docs.rs/cloudevents-sdk) docs for more details on how to use [`cloudevents::Event`].
+
+#![doc(html_root_url = "https://docs.rs/cloudevents-sdk-surf/0.3.1")]
+#![deny(broken_intra_doc_links)]
+
+#[macro_use]
+mod headers;
+mod client_request;
+mod client_response;
+
+pub use client_request::event_to_request;
+pub use client_request::RequestExt;
+pub use client_request::RequestSerializer;
+pub use client_response::response_to_event;
+pub use client_response::ResponseDeserializer;
+pub use client_response::ResponseExt;


### PR DESCRIPTION
Signed-off-by: Anthony Whalley <anton@venshare.com>
This PR provides an async-std client to compliment the tide async-std service.
https://github.com/http-rs/surf
If follows the reqwest implementation as closely as possible while leveraging similar patterns used in the tide implementation.

