### PR TITLE
Use stream() instead of deprecated start()

### DIFF
--- a/example-projects/rdkafka-example/src/main.rs
+++ b/example-projects/rdkafka-example/src/main.rs
@@ -31,9 +31,9 @@ async fn consume(brokers: &str, group_id: &str, topics: &[&str]) {
         .subscribe(&topics.to_vec())
         .expect("Can't subscribe to specified topics");
 
-    // consumer.start() returns a stream. The stream can be used ot chain together expensive steps,
+    // consumer.stream() returns a stream. The stream can be used ot chain together expensive steps,
     // such as complex computations on a thread pool or asynchronous IO.
-    let mut message_stream = consumer.start();
+    let mut message_stream = consumer.stream();
 
     while let Some(message) = message_stream.next().await {
         match message {


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

```
warning: use of deprecated associated function `rdkafka::consumer::StreamConsumer::<C, R>::start`: use the more clearly named "StreamConsumer::stream" method instead

```

Using the `stream` instead of the deprecated `start`, see also here:
https://github.com/fede1024/rust-rdkafka/blob/5d23e82a675d9df1bf343aedcaa35be864787dab/src/consumer/stream_consumer.rs#L321-L325