### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -120,8 +120,7 @@ impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "CloudEvent:")?;
         self.iter()
-            .map(|(name, val)| writeln!(f, "  {}: '{}'", name, val))
-            .collect::<fmt::Result>()?;
+            .try_for_each(|(name, val)| writeln!(f, "  {}: '{}'", name, val))?;
         match self.data() {
             Some(data) => write!(f, "  {}", data)?,
             None => write!(f, "  No data")?,

--- a/src/message/types.rs
+++ b/src/message/types.rs
@@ -54,9 +54,9 @@ impl fmt::Display for MessageAttributeValue {
     }
 }
 
-impl Into<MessageAttributeValue> for ExtensionValue {
-    fn into(self) -> MessageAttributeValue {
-        match self {
+impl From<ExtensionValue> for MessageAttributeValue {
+    fn from(that: ExtensionValue) -> Self {
+        match that {
             ExtensionValue::String(s) => MessageAttributeValue::String(s),
             ExtensionValue::Boolean(b) => MessageAttributeValue::Boolean(b),
             ExtensionValue::Integer(i) => MessageAttributeValue::Integer(i),
@@ -64,9 +64,9 @@ impl Into<MessageAttributeValue> for ExtensionValue {
     }
 }
 
-impl Into<ExtensionValue> for MessageAttributeValue {
-    fn into(self) -> ExtensionValue {
-        match self {
+impl From<MessageAttributeValue> for ExtensionValue {
+    fn from(that: MessageAttributeValue) -> Self {
+        match that {
             MessageAttributeValue::Integer(i) => ExtensionValue::Integer(i),
             MessageAttributeValue::Boolean(b) => ExtensionValue::Boolean(b),
             v => ExtensionValue::String(v.to_string()),

--- a/src/warp/server_request.rs
+++ b/src/warp/server_request.rs
@@ -63,7 +63,7 @@ impl BinaryDeserializer for RequestDeserializer {
             )?
         }
 
-        if self.body.len() != 0 {
+        if !self.body.is_empty() {
             visitor.end_with_data(self.body.to_vec())
         } else {
             visitor.end()

--- a/src/warp/server_response.rs
+++ b/src/warp/server_response.rs
@@ -84,8 +84,7 @@ impl BinarySerializer<Response> for ResponseSerializer {
 
 impl StructuredSerializer<Response> for ResponseSerializer {
     fn set_structured_event(self, bytes: Vec<u8>) -> Result<Response> {
-        Ok(self
-            .builder
+        self.builder
             .header(
                 http::header::CONTENT_TYPE,
                 headers::CLOUDEVENTS_JSON_HEADER.clone(),
@@ -93,7 +92,7 @@ impl StructuredSerializer<Response> for ResponseSerializer {
             .body(Body::from(bytes))
             .map_err(|e| crate::message::Error::Other {
                 source: Box::new(e),
-            })?)
+            })
     }
 }
 


### PR DESCRIPTION
I think these are mostly harmless. There are apparently good reasons for implementing `Into` instead of `From`, e.g. supporting older Rust versions, but according to clippy, `From` is preferred.