### PR TITLE
Fix null context attributes in json

### DIFF
--- a/src/event/data.rs
+++ b/src/event/data.rs
@@ -36,6 +36,12 @@ impl From<String> for Data {
     }
 }
 
+impl From<&str> for Data {
+    fn from(value: &str) -> Self {
+        Data::String(String::from(value))
+    }
+}
+
 impl TryFrom<Data> for serde_json::Value {
     type Error = serde_json::Error;
 

--- a/src/event/format.rs
+++ b/src/event/format.rs
@@ -23,12 +23,14 @@ macro_rules! parse_field {
 macro_rules! extract_optional_field {
     ($map:ident, $name:literal, $target_type:ty, $error:ty) => {
         $map.remove($name)
+            .filter(|v| !v.is_null())
             .map(|v| parse_field!(v, $target_type, $error))
             .transpose()
     };
 
     ($map:ident, $name:literal, $target_type:ty, $error:ty, $mapper:expr) => {
         $map.remove($name)
+            .filter(|v| !v.is_null())
             .map(|v| parse_field!(v, $target_type, $error, $mapper))
             .transpose()
     };
@@ -93,6 +95,7 @@ pub(crate) trait EventFormatDeserializer {
         )?;
         let extensions = map
             .into_iter()
+            .filter(|v| !v.1.is_null())
             .map(|(k, v)| {
                 Ok((
                     k,

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -1,7 +1,7 @@
 use claim::*;
-use cloudevents::Event;
+use cloudevents::{Event, EventBuilderV10, EventBuilder};
 use rstest::rstest;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 mod test_data;
 use test_data::*;
@@ -82,6 +82,68 @@ fn serialize_should_succeed(in_event: Event, out_json: Value) {
     )
 )]
 fn deserialize_should_succeed(in_json: Value, out_event: Event) {
+    let deserialize_result: Result<Event, serde_json::Error> = serde_json::from_value(in_json);
+    assert_ok!(&deserialize_result);
+    let deserialize_json = deserialize_result.unwrap();
+    assert_eq!(deserialize_json, out_event)
+}
+
+#[test]
+fn deserialize_with_null_attribute() {
+    let in_json = json!({
+        "specversion" : "1.0",
+        "type" : "com.example.someevent",
+        "source" : "/mycontext",
+        "id" : "A234-1234-1234",
+        "time" : null,
+        "comexampleextension1" : "value",
+        "comexampleothervalue" : 5,
+        "datacontenttype" : "text/xml",
+        "data" : "<much wow=\"xml\"/>"
+    });
+
+    let out_event = EventBuilderV10::new()
+        .ty("com.example.someevent")
+        .source("/mycontext")
+        .id("A234-1234-1234")
+        .data("text/xml", "<much wow=\"xml\"/>")
+        .extension("comexampleextension1", "value")
+        .extension("comexampleothervalue", 5)
+        .build()
+        .unwrap();
+
+    let deserialize_result: Result<Event, serde_json::Error> = serde_json::from_value(in_json);
+    assert_ok!(&deserialize_result);
+    let deserialize_json = deserialize_result.unwrap();
+    assert_eq!(deserialize_json, out_event)
+}
+
+#[test]
+fn deserialize_with_null_ext() {
+    let in_json = json!({
+        "specversion" : "1.0",
+        "type" : "com.example.someevent",
+        "source" : "/mycontext",
+        "id" : "A234-1234-1234",
+        "time" : "2018-04-05T17:31:00Z",
+        "comexampleextension1" : "value",
+        "comexampleothervalue" : 5,
+        "unsetextension": null,
+        "datacontenttype" : "text/xml",
+        "data" : "<much wow=\"xml\"/>"
+    });
+
+    let out_event = EventBuilderV10::new()
+        .ty("com.example.someevent")
+        .source("/mycontext")
+        .id("A234-1234-1234")
+        .time("2018-04-05T17:31:00Z")
+        .data("text/xml", "<much wow=\"xml\"/>")
+        .extension("comexampleextension1", "value")
+        .extension("comexampleothervalue", 5)
+        .build()
+        .unwrap();
+
     let deserialize_result: Result<Event, serde_json::Error> = serde_json::from_value(in_json);
     assert_ok!(&deserialize_result);
     let deserialize_json = deserialize_result.unwrap();

--- a/tests/serde_json.rs
+++ b/tests/serde_json.rs
@@ -1,5 +1,5 @@
 use claim::*;
-use cloudevents::{Event, EventBuilderV10, EventBuilder};
+use cloudevents::{Event, EventBuilder, EventBuilderV10};
 use rstest::rstest;
 use serde_json::{json, Value};
 


### PR DESCRIPTION
Fix #125. Per spec, these fields are ignored and handled as missing.

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>