### PR TITLE
Release 0.4 bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudevents-sdk"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Francesco Guardiani <francescoguard@gmail.com>"]
 license-file = "LICENSE"
 edition = "2018"
@@ -55,7 +55,7 @@ uuid = { version = "^0.8", features = ["v4", "wasm-bindgen"] }
 [dev-dependencies]
 rstest = "0.6"
 claim = "0.3.1"
-version-sync = "^0.9"
+version-sync = "0.9.2"
 serde_yaml = "0.8"
 
 # runtime dev-deps

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ enabling your Protocol Binding of choice:
 
 ```toml
 [dependencies]
-cloudevents-sdk = { version = "0.3.1", features = ["actix"] }
+cloudevents-sdk = { version = "0.4.0" }
 ```
 
 Now you can start creating events:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 //! [Extractors]: https://actix.rs/docs/extractors/
 //! [Responders]: https://actix.rs/docs/handlers/
 
+#![doc(html_root_url = "https://docs.rs/cloudevents-sdk/0.4.0")]
 #![deny(broken_intra_doc_links)]
 
 pub mod binding;


### PR DESCRIPTION
`cargo publish --dry-run` passes, test and doc build passes as well

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>