### PR TITLE
Use defined fixtures in tests

### DIFF
--- a/src/binding/actix/server_response.rs
+++ b/src/binding/actix/server_response.rs
@@ -71,21 +71,14 @@ mod private {
 mod tests {
     use super::*;
 
-    use crate::{EventBuilder, EventBuilderV10};
+    use crate::test::fixtures;
     use actix_web::http::StatusCode;
     use actix_web::test;
     use futures::TryStreamExt;
-    use serde_json::json;
 
     #[actix_rt::test]
     async fn test_response() {
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::minimal_string_extension();
 
         let resp = HttpResponseBuilder::new(StatusCode::OK)
             .event(input)
@@ -106,7 +99,7 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
@@ -120,16 +113,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_response_with_full_data() {
-        let j = json!({"hello": "world"});
-
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::full_binary_json_data_string_extension();
 
         let mut resp = HttpResponseBuilder::new(StatusCode::OK)
             .event(input)
@@ -150,11 +134,11 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
-            "http://localhost"
+            "http://localhost/"
         );
         assert_eq!(
             resp.headers()
@@ -165,13 +149,13 @@ mod tests {
             "application/json"
         );
         assert_eq!(
-            resp.headers().get("ce-someint").unwrap().to_str().unwrap(),
+            resp.headers().get("ce-int_ex").unwrap().to_str().unwrap(),
             "10"
         );
 
         let bytes = test::load_stream(resp.take_body().into_stream())
             .await
             .unwrap();
-        assert_eq!(j.to_string().as_bytes(), bytes.as_ref())
+        assert_eq!(fixtures::json_data_binary(), bytes.as_ref())
     }
 }

--- a/src/binding/axum/extract.rs
+++ b/src/binding/axum/extract.rs
@@ -47,32 +47,21 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{self, Request, StatusCode};
-    use chrono::Utc;
-    use serde_json::json;
 
-    use crate::{EventBuilder, EventBuilderV10};
+    use crate::test::fixtures;
 
     #[tokio::test]
     async fn axum_test_request() {
-        let time = Utc::now();
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .time(time)
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::minimal_string_extension();
 
         let mut request = RequestParts::new(
             Request::builder()
                 .method(http::Method::POST)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", "0001")
-                .header("ce-type", "example.test")
+                .header("ce-type", "test_event.test_application")
                 .header("ce-source", "http://localhost/")
                 .header("ce-someint", "10")
-                .header("ce-time", time.to_rfc3339())
                 .body(Body::empty())
                 .unwrap(),
         );
@@ -84,8 +73,6 @@ mod tests {
 
     #[tokio::test]
     async fn axum_test_bad_request() {
-        let time = Utc::now();
-
         let mut request = RequestParts::new(
             Request::builder()
                 .method(http::Method::POST)
@@ -94,7 +81,7 @@ mod tests {
                 .header("ce-type", "example.test")
                 .header("ce-source", "http://localhost/")
                 .header("ce-someint", "10")
-                .header("ce-time", time.to_rfc3339())
+                .header("ce-time", fixtures::time().to_rfc3339())
                 .body(Body::empty())
                 .unwrap(),
         );
@@ -109,30 +96,22 @@ mod tests {
 
     #[tokio::test]
     async fn axum_test_request_with_full_data() {
-        let time = Utc::now();
-        let j = json!({"hello": "world"});
-
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .time(time)
-            .data("application/json", j.to_string().into_bytes())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::full_binary_json_data_string_extension();
 
         let mut request = RequestParts::new(
             Request::builder()
                 .method(http::Method::POST)
                 .header("ce-specversion", "1.0")
                 .header("ce-id", "0001")
-                .header("ce-type", "example.test")
-                .header("ce-source", "http://localhost")
-                .header("ce-someint", "10")
-                .header("ce-time", time.to_rfc3339())
+                .header("ce-type", "test_event.test_application")
+                .header("ce-source", "http://localhost/")
+                .header("ce-subject", "cloudevents-sdk")
                 .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&j).unwrap()))
+                .header("ce-string_ex", "val")
+                .header("ce-int_ex", "10")
+                .header("ce-bool_ex", "true")
+                .header("ce-time", &fixtures::time().to_rfc3339())
+                .body(Body::from(fixtures::json_data_binary()))
                 .unwrap(),
         );
 

--- a/src/binding/axum/response.rs
+++ b/src/binding/axum/response.rs
@@ -25,19 +25,12 @@ impl IntoResponse for Event {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
-    use crate::{EventBuilder, EventBuilderV10};
+    use crate::test::fixtures;
 
     #[test]
     fn axum_test_response() {
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::minimal_string_extension();
 
         let resp = input.into_response();
 
@@ -55,7 +48,7 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
@@ -69,16 +62,7 @@ mod tests {
 
     #[tokio::test]
     async fn axum_test_response_with_full_data() {
-        let j = json!({"hello": "world"});
-
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::full_binary_json_data_string_extension();
 
         let resp = input.into_response();
 
@@ -96,11 +80,11 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
-            "http://localhost"
+            "http://localhost/"
         );
         assert_eq!(
             resp.headers()
@@ -111,13 +95,13 @@ mod tests {
             "application/json"
         );
         assert_eq!(
-            resp.headers().get("ce-someint").unwrap().to_str().unwrap(),
+            resp.headers().get("ce-int_ex").unwrap().to_str().unwrap(),
             "10"
         );
 
         let (_, body) = resp.into_parts();
         let body = hyper::body::to_bytes(body).await.unwrap();
 
-        assert_eq!(j.to_string().as_bytes(), body);
+        assert_eq!(fixtures::json_data_binary(), body);
     }
 }

--- a/src/binding/rdkafka/kafka_consumer_record.rs
+++ b/src/binding/rdkafka/kafka_consumer_record.rs
@@ -173,22 +173,12 @@ mod tests {
     use super::*;
     use crate::binding::rdkafka::kafka_producer_record::MessageRecord;
 
+    use crate::test::fixtures;
     use crate::{EventBuilder, EventBuilderV10};
-    use chrono::Utc;
-    use serde_json::json;
 
     #[test]
     fn test_binary_record() {
-        let time = Utc::now();
-
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .time(time)
-            .source("http://localhost")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::minimal_string_extension();
 
         // Since there is neither a way provided by rust-rdkafka to convert FutureProducer back into
         // OwnedMessage or BorrowedMessage, nor is there a way to create a BorrowedMessage struct,
@@ -198,9 +188,8 @@ mod tests {
         let message_record = MessageRecord::from_event(
             EventBuilderV10::new()
                 .id("0001")
-                .ty("example.test")
-                .time(time)
-                .source("http://localhost")
+                .ty("test_event.test_application")
+                .source("http://localhost/")
                 .extension("someint", "10")
                 .build()
                 .unwrap(),
@@ -222,30 +211,14 @@ mod tests {
 
     #[test]
     fn test_structured_record() {
-        let j = json!({"hello": "world"});
-
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::full_json_data_string_extension();
 
         // Since there is neither a way provided by rust-rdkafka to convert FutureProducer back into
         // OwnedMessage or BorrowedMessage, nor is there a way to create a BorrowedMessage struct,
         // the test uses OwnedMessage instead, which consumes the message instead of borrowing it like
         // in the case of BorrowedMessage
 
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j)
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = expected.clone();
 
         let serialized_event =
             StructuredDeserializer::deserialize_structured(input, MessageRecord::new()).unwrap();

--- a/src/binding/reqwest/client_request.rs
+++ b/src/binding/reqwest/client_request.rs
@@ -101,8 +101,7 @@ mod tests {
     use reqwest_lib as reqwest;
 
     use crate::message::StructuredDeserializer;
-    use crate::{EventBuilder, EventBuilderV10};
-    use serde_json::json;
+    use crate::test::fixtures;
 
     #[tokio::test]
     async fn test_request() {
@@ -110,19 +109,13 @@ mod tests {
         let m = mock("POST", "/")
             .match_header("ce-specversion", "1.0")
             .match_header("ce-id", "0001")
-            .match_header("ce-type", "example.test")
+            .match_header("ce-type", "test_event.test_application")
             .match_header("ce-source", "http://localhost/")
             .match_header("ce-someint", "10")
             .match_body(Matcher::Missing)
             .create();
 
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::minimal_string_extension();
 
         let client = reqwest::Client::new();
         client
@@ -138,27 +131,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_with_full_data() {
-        let j = json!({"hello": "world"});
-
         let url = mockito::server_url();
         let m = mock("POST", "/")
             .match_header("ce-specversion", "1.0")
             .match_header("ce-id", "0001")
-            .match_header("ce-type", "example.test")
-            .match_header("ce-source", "http://localhost/")
-            .match_header("content-type", "application/json")
-            .match_header("ce-someint", "10")
-            .match_body(Matcher::Exact(j.to_string()))
+            .with_header("ce-type", "test_event.test_application")
+            .with_header("ce-source", "http://localhost/")
+            .with_header("ce-subject", "cloudevents-sdk")
+            .with_header("content-type", "application/json")
+            .with_header("ce-string_ex", "val")
+            .with_header("ce-int_ex", "10")
+            .with_header("ce-bool_ex", "true")
+            .with_header("ce-time", &fixtures::time().to_rfc3339())
+            .match_body(Matcher::Exact(fixtures::json_data().to_string()))
             .create();
 
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::full_binary_json_data_string_extension();
 
         let client = reqwest::Client::new();
 
@@ -175,16 +163,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_structured_request_with_full_data() {
-        let j = json!({"hello": "world"});
-
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::full_json_data_string_extension();
 
         let url = mockito::server_url();
         let m = mock("POST", "/")

--- a/src/binding/reqwest/client_response.rs
+++ b/src/binding/reqwest/client_response.rs
@@ -45,34 +45,21 @@ mod tests {
     use mockito::mock;
     use reqwest_lib as reqwest;
 
-    use crate::{EventBuilder, EventBuilderV10};
-    use chrono::Utc;
-    use serde_json::json;
+    use crate::test::fixtures;
 
     #[tokio::test]
     async fn test_response() {
-        let time = Utc::now();
         let url = mockito::server_url();
         let _m = mock("GET", "/")
             .with_status(200)
             .with_header("ce-specversion", "1.0")
             .with_header("ce-id", "0001")
-            .with_header("ce-type", "example.test")
-            .with_header("ce-source", "http://localhost")
+            .with_header("ce-type", "test_event.test_application")
+            .with_header("ce-source", "http://localhost/")
             .with_header("ce-someint", "10")
-            .with_header("ce-time", &time.to_rfc3339())
             .create();
 
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            //TODO this is required now because the message deserializer implictly set default values
-            // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
-            .time(time)
-            .source("http://localhost")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::minimal_string_extension();
 
         let client = reqwest::Client::new();
         let res = client
@@ -89,33 +76,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_response_with_full_data() {
-        let time = Utc::now();
-        let j = json!({"hello": "world"});
-
         let url = mockito::server_url();
         let _m = mock("GET", "/")
             .with_status(200)
             .with_header("ce-specversion", "1.0")
             .with_header("ce-id", "0001")
-            .with_header("ce-type", "example.test")
+            .with_header("ce-type", "test_event.test_application")
             .with_header("ce-source", "http://localhost/")
+            .with_header("ce-subject", "cloudevents-sdk")
             .with_header("content-type", "application/json")
-            .with_header("ce-someint", "10")
-            .with_header("ce-time", &time.to_rfc3339())
-            .with_body(j.to_string())
+            .with_header("ce-string_ex", "val")
+            .with_header("ce-int_ex", "10")
+            .with_header("ce-bool_ex", "true")
+            .with_header("ce-time", &fixtures::time().to_rfc3339())
+            .with_body(fixtures::json_data().to_string())
             .create();
 
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            //TODO this is required now because the message deserializer implictly set default values
-            // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
-            .time(time)
-            .source("http://localhost/")
-            .data("application/json", j.to_string().into_bytes())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::full_binary_json_data_string_extension();
 
         let client = reqwest::Client::new();
         let res = client
@@ -132,20 +109,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_structured_response_with_full_data() {
-        let time = Utc::now();
-
-        let j = json!({"hello": "world"});
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            //TODO this is required now because the message deserializer implictly set default values
-            // As soon as this defaulting doesn't happen anymore, we can remove it (Issues #40/#41)
-            .time(time)
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::full_json_data_string_extension();
 
         let url = mockito::server_url();
         let _m = mock("GET", "/")

--- a/src/binding/warp/filter.rs
+++ b/src/binding/warp/filter.rs
@@ -49,30 +49,19 @@ mod tests {
     use super::to_event;
     use warp::test;
 
-    use crate::{EventBuilder, EventBuilderV10};
-    use chrono::Utc;
-    use serde_json::json;
+    use crate::test::fixtures;
 
     #[tokio::test]
     async fn test_request() {
-        let time = Utc::now();
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .time(time)
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::minimal_string_extension();
 
         let result = test::request()
             .method("POST")
             .header("ce-specversion", "1.0")
             .header("ce-id", "0001")
-            .header("ce-type", "example.test")
+            .header("ce-type", "test_event.test_application")
             .header("ce-source", "http://localhost/")
             .header("ce-someint", "10")
-            .header("ce-time", time.to_rfc3339())
             .filter(&to_event())
             .await
             .unwrap();
@@ -82,8 +71,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_bad_request() {
-        let time = Utc::now();
-
         let result = test::request()
             .method("POST")
             .header("ce-specversion", "BAD SPECIFICATION")
@@ -91,7 +78,7 @@ mod tests {
             .header("ce-type", "example.test")
             .header("ce-source", "http://localhost/")
             .header("ce-someint", "10")
-            .header("ce-time", time.to_rfc3339())
+            .header("ce-time", fixtures::time().to_rfc3339())
             .filter(&to_event())
             .await;
 
@@ -107,29 +94,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_with_full_data() {
-        let time = Utc::now();
-        let j = json!({"hello": "world"});
-
-        let expected = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .time(time)
-            .data("application/json", j.to_string().into_bytes())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let expected = fixtures::v10::full_binary_json_data_string_extension();
 
         let result = test::request()
             .method("POST")
             .header("ce-specversion", "1.0")
             .header("ce-id", "0001")
-            .header("ce-type", "example.test")
-            .header("ce-source", "http://localhost")
-            .header("ce-someint", "10")
-            .header("ce-time", time.to_rfc3339())
+            .header("ce-type", "test_event.test_application")
+            .header("ce-source", "http://localhost/")
+            .header("ce-subject", "cloudevents-sdk")
             .header("content-type", "application/json")
-            .json(&j)
+            .header("ce-string_ex", "val")
+            .header("ce-int_ex", "10")
+            .header("ce-bool_ex", "true")
+            .header("ce-time", &fixtures::time().to_rfc3339())
+            .json(&fixtures::json_data())
             .filter(&to_event())
             .await
             .unwrap();

--- a/src/binding/warp/reply.rs
+++ b/src/binding/warp/reply.rs
@@ -31,18 +31,11 @@ pub fn from_event(event: Event) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use crate::{EventBuilder, EventBuilderV10};
-    use serde_json::json;
+    use crate::test::fixtures;
 
     #[test]
     fn test_response() {
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost/")
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::minimal_string_extension();
 
         let resp = super::from_event(input);
 
@@ -60,7 +53,7 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
@@ -74,16 +67,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_response_with_full_data() {
-        let j = json!({"hello": "world"});
-
-        let input = EventBuilderV10::new()
-            .id("0001")
-            .ty("example.test")
-            .source("http://localhost")
-            .data("application/json", j.clone())
-            .extension("someint", "10")
-            .build()
-            .unwrap();
+        let input = fixtures::v10::full_binary_json_data_string_extension();
 
         let resp = super::from_event(input);
 
@@ -101,11 +85,11 @@ mod tests {
         );
         assert_eq!(
             resp.headers().get("ce-type").unwrap().to_str().unwrap(),
-            "example.test"
+            "test_event.test_application"
         );
         assert_eq!(
             resp.headers().get("ce-source").unwrap().to_str().unwrap(),
-            "http://localhost"
+            "http://localhost/"
         );
         assert_eq!(
             resp.headers()
@@ -116,13 +100,13 @@ mod tests {
             "application/json"
         );
         assert_eq!(
-            resp.headers().get("ce-someint").unwrap().to_str().unwrap(),
+            resp.headers().get("ce-int_ex").unwrap().to_str().unwrap(),
             "10"
         );
 
         let (_, body) = resp.into_parts();
         let body = hyper::body::to_bytes(body).await.unwrap();
 
-        assert_eq!(j.to_string().as_bytes(), body);
+        assert_eq!(fixtures::json_data_binary(), body);
     }
 }

--- a/src/test/fixtures/v10.rs
+++ b/src/test/fixtures/v10.rs
@@ -12,6 +12,16 @@ pub fn minimal() -> Event {
         .unwrap()
 }
 
+pub fn minimal_string_extension() -> Event {
+    EventBuilderV10::new()
+        .id(id())
+        .source(source())
+        .ty(ty())
+        .extension("someint", "10")
+        .build()
+        .unwrap()
+}
+
 pub fn minimal_json() -> Value {
     json!({
         "specversion": "1.0",
@@ -76,6 +86,44 @@ pub fn full_json_data() -> Event {
             Url::parse(dataschema().as_ref()).unwrap(),
             json_data(),
         )
+        .build()
+        .unwrap()
+}
+
+pub fn full_json_data_string_extension() -> Event {
+    let (string_ext_name, string_ext_value) = string_extension();
+    let (bool_ext_name, bool_ext_value) = bool_extension();
+    let (int_ext_name, int_ext_value) = int_extension();
+
+    EventBuilderV10::new()
+        .id(id())
+        .source(source())
+        .ty(ty())
+        .subject(subject())
+        .time(time())
+        .extension(&string_ext_name, string_ext_value)
+        .extension(&bool_ext_name, bool_ext_value.to_string())
+        .extension(&int_ext_name, int_ext_value.to_string())
+        .data(json_datacontenttype(), json_data())
+        .build()
+        .unwrap()
+}
+
+pub fn full_binary_json_data_string_extension() -> Event {
+    let (string_ext_name, string_ext_value) = string_extension();
+    let (bool_ext_name, bool_ext_value) = bool_extension();
+    let (int_ext_name, int_ext_value) = int_extension();
+
+    EventBuilderV10::new()
+        .id(id())
+        .source(source())
+        .ty(ty())
+        .subject(subject())
+        .time(time())
+        .extension(&string_ext_name, string_ext_value)
+        .extension(&bool_ext_name, bool_ext_value.to_string())
+        .extension(&int_ext_name, int_ext_value.to_string())
+        .data(json_datacontenttype(), json_data().to_string().into_bytes())
         .build()
         .unwrap()
 }


### PR DESCRIPTION
This is an effort to use defined fixtures in tests to reduce copy/pasting and provide more uniform tests among features.