### PR TITLE
Batch Event implementation for reqwest bindings

### DIFF
--- a/src/binding/mod.rs
+++ b/src/binding/mod.rs
@@ -52,6 +52,7 @@ pub(crate) mod kafka {
 }
 
 pub(crate) static CLOUDEVENTS_JSON_HEADER: &str = "application/cloudevents+json";
+pub(crate) static CLOUDEVENTS_BATCH_JSON_HEADER: &str = "application/cloudevents-batch+json";
 pub(crate) static CONTENT_TYPE: &str = "content-type";
 
 fn header_prefix(prefix: &str, name: &str) -> String {


### PR DESCRIPTION
Added `events(Vec<Event>)` to `RequestBuilderExt` to provide a batched set of Events to send to an HTTP endpoint, and
`into_events() -> Result<Vec<Event>>` to `ResponseExt` to parse a batched Event response.

I deliberately kept things simple, as I thought this would be a good place to start with Batch support throughout the SDK, and the implementation was simple enough, that there didn't seem to be much opportunity for reusable libraries across the SDK. That could be changed as more Batch support is provided across the SDK, and opportunities for code reuse present themselves.