### PR TITLE
remove unnecessary clones

### DIFF
--- a/src/binding/http/deserializer.rs
+++ b/src/binding/http/deserializer.rs
@@ -34,9 +34,9 @@ impl<'a, T: Headers<'a>> BinaryDeserializer for Deserializer<'a, T> {
                 .unwrap()?,
         )?;
 
-        visitor = visitor.set_spec_version(spec_version.clone())?;
-
         let attributes = spec_version.attribute_names();
+
+        visitor = visitor.set_spec_version(spec_version)?;
 
         for (hn, hv) in self.headers.iter().filter(|(hn, _)| {
             let key = hn.as_str();

--- a/src/binding/rdkafka/kafka_consumer_record.rs
+++ b/src/binding/rdkafka/kafka_consumer_record.rs
@@ -51,9 +51,9 @@ impl BinaryDeserializer for ConsumerRecordDeserializer {
             })?,
         )?;
 
-        visitor = visitor.set_spec_version(spec_version.clone())?;
-
         let attributes = spec_version.attribute_names();
+
+        visitor = visitor.set_spec_version(spec_version)?;
 
         if let Some(hv) = self.headers.remove(CONTENT_TYPE) {
             visitor = visitor.set_attribute(


### PR DESCRIPTION
Just stumbled over this `clone` today. 

By first calling `attribute_names()` the `clone` becomes unnecessary.

*<insert "It's not much, but it is honest work" meme>*