### PR TITLE
Update rdkafka-lib version to ^0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ uuid = { version = "1", features = ["v4"] }
 actix-web = { version = "4", optional = true }
 actix-http = { version = "3", optional = true }
 reqwest-lib = { version = "^0.11", default-features = false, features = ["rustls-tls"], optional = true, package = "reqwest" }
-rdkafka-lib = { version = "^0.29", features = ["cmake-build"], optional = true, package = "rdkafka" }
+rdkafka-lib = { version = "^0.36", features = ["cmake-build"], optional = true, package = "rdkafka" }
 warp-lib = { version = "^0.3", optional = true, package = "warp" }
 async-trait = { version = "^0.1.33", optional = true }
 bytes = { version = "^1.0", optional = true }

--- a/example-projects/rdkafka-example/Cargo.toml
+++ b/example-projects/rdkafka-example/Cargo.toml
@@ -16,4 +16,4 @@ serde_json = "^1.0"
 futures = "^0.3"
 tokio = { version = "^1.0", features = ["full"] }
 clap = "2.33.1"
-rdkafka = { version = "^0.29", features = ["cmake-build"] }
+rdkafka = { version = "^0.36", features = ["cmake-build"] }


### PR DESCRIPTION
The rdkafka-lib version being used has been updated from ^0.29 to ^0.36. This update in the package version is necessary for better compatibility with the latest kafka features.