### PR TITLE
Fix wasm-bindgen-maro issue.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
     ".github/*"
 ]
 categories = ["web-programming", "encoding", "data-structures"]
+resolver = "2"
 
 # Enable all features when building on docs.rs to show feature gated bindings
 [package.metadata.docs.rs]

--- a/example-projects/reqwest-wasm-example/Cargo.toml
+++ b/example-projects/reqwest-wasm-example/Cargo.toml
@@ -3,6 +3,7 @@ name = "reqwest-wasm-example"
 version = "0.3.0"
 authors = ["Francesco Guardiani <francescoguard@gmail.com>"]
 edition = "2018"
+resolver = "2"
 
 # Config mostly pulled from: https://github.com/rustwasm/wasm-bindgen/blob/master/examples/fetch/Cargo.toml
 


### PR DESCRIPTION
This fixes the build issue caused by https://github.com/rustwasm/wasm-bindgen/issues/4304 
@smoelius helped me troubleshoot this, see previous try here https://github.com/ozabalaferrera/cloudevents-sdk-rust/pull/2#issuecomment-2514183191 
