### PR TITLE
Update rdkafka, axum, and http.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudevents-sdk"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Francesco Guardiani <francescoguard@gmail.com>"]
 license-file = "LICENSE"
 edition = "2018"
@@ -48,12 +48,12 @@ uuid = { version = "1", features = ["v4"] }
 actix-web = { version = "4", optional = true }
 actix-http = { version = "3", optional = true }
 reqwest-lib = { version = "^0.12", default-features = false, features = ["rustls-tls"], optional = true, package = "reqwest" }
-rdkafka-lib = { version = "^0.36", features = ["cmake-build"], optional = true, package = "rdkafka" }
+rdkafka-lib = { version = "^0.37", features = ["cmake-build"], optional = true, package = "rdkafka" }
 warp-lib = { version = "^0.3", optional = true, package = "warp" }
 async-trait = { version = "^0.1", optional = true }
 bytes = { version = "^1.0", optional = true }
 futures = { version = "^0.3", optional = true, features = ["compat"]}
-http = { version = "1.1", optional = true}
+http = { version = "1.2", optional = true}
 http-0-2 = { version = "0.2", optional = true, package = "http"}
 axum-lib = { version = "^0.7", optional = true, package="axum"}
 http-body-util = {version = "^0.1", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bytes = { version = "^1.0", optional = true }
 futures = { version = "^0.3", optional = true, features = ["compat"]}
 http = { version = "1.2", optional = true}
 http-0-2 = { version = "0.2", optional = true, package = "http"}
-axum-lib = { version = "^0.7", optional = true, package="axum"}
+axum-lib = { version = "^0.8", optional = true, package="axum"}
 http-body-util = {version = "^0.1", optional = true}
 poem-lib = { version = "^3.1", optional = true, package = "poem" }
 nats-lib = { version = "0.25.0", optional = true, package = "nats" }
@@ -67,7 +67,7 @@ hostname = "^0.4"
 web-sys = { version = "^0.3", features = ["Window", "Location"] }
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
-hyper = { version = "^1.4", optional = true, package="hyper" }
+hyper = { version = "^1.5", optional = true, package="hyper" }
 hyper-0-14 = { version = "^0.14", optional = true, package = "hyper"}
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
@@ -75,7 +75,7 @@ hyper_wasi = { version = "0.15", features = ["full"], optional = true }
 
 [dev-dependencies]
 rstest = "0.23"
-claims = "0.7.1"
+claims = "0.8"
 version-sync = "0.9.2"
 serde_yaml = "^0.9"
 rmp-serde = "1"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ enabling your Protocol Binding of choice:
 
 ```toml
 [dependencies]
-cloudevents-sdk = { version = "0.8.0" }
+cloudevents-sdk = { version = "0.9.0" }
 ```
 
 Now you can start creating events:

--- a/example-projects/axum-example/Cargo.toml
+++ b/example-projects/axum-example/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 
 [dependencies]
 cloudevents-sdk = { path = "../..", features = ["axum"] }
-axum = "^0.7"
+axum = "^0.8"
 http = "^1.1"
 tokio = { version = "^1", features = ["full"] }
 tracing = "^0.1"
 tracing-subscriber = "^0.3"
-tower-http = { version = "^0.5", features = ["trace"] }
+tower-http = { version = "^0.6", features = ["trace"] }
 
 [dev-dependencies]
-tower = { version = "^0.4", features = ["util"] }
+tower = { version = "^0.5", features = ["util"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 chrono = { version = "^0.4", features = ["serde"] }

--- a/example-projects/rdkafka-example/Cargo.toml
+++ b/example-projects/rdkafka-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka-example"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Pranav Bhatt <adpranavb2000@gmail.com>"]
 edition = "2018"
 
@@ -16,4 +16,4 @@ serde_json = "^1.0"
 futures = "^0.3"
 tokio = { version = "^1.0", features = ["full"] }
 clap = "2.33.1"
-rdkafka = { version = "^0.36", features = ["cmake-build"] }
+rdkafka = { version = "^0.37", features = ["cmake-build"] }

--- a/src/binding/axum/extract.rs
+++ b/src/binding/axum/extract.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use axum::body::Bytes;
 use axum::extract::{FromRequest, Request};
 use axum::response::Response;
@@ -9,7 +8,6 @@ use http::StatusCode;
 use crate::binding::http::to_event;
 use crate::event::Event;
 
-#[async_trait]
 impl<S> FromRequest<S> for Event
 where
     Bytes: FromRequest<S>,

--- a/src/event/attributes.rs
+++ b/src/event/attributes.rs
@@ -2,6 +2,7 @@ use super::{
     AttributesIntoIteratorV03, AttributesIntoIteratorV10, AttributesV03, AttributesV10,
     ExtensionValue, SpecVersion, UriReference,
 };
+use base64::prelude::*;
 use chrono::{DateTime, Utc};
 use serde::Serializer;
 use std::fmt;
@@ -37,7 +38,7 @@ impl fmt::Display for AttributeValue<'_> {
             AttributeValue::Boolean(b) => f.serialize_bool(**b),
             AttributeValue::Integer(i) => f.serialize_i64(**i),
             AttributeValue::String(s) => f.write_str(s),
-            AttributeValue::Binary(b) => f.write_str(&base64::encode(b)),
+            AttributeValue::Binary(b) => f.write_str(&BASE64_STANDARD.encode(b)),
             AttributeValue::URI(s) => f.write_str(s.as_str()),
             AttributeValue::URIRef(s) => f.write_str(s.as_str()),
             AttributeValue::Time(s) => f.write_str(&s.to_rfc3339()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! [Extractors]: https://actix.rs/docs/extractors/
 //! [Responders]: https://actix.rs/docs/handlers/
 
-#![doc(html_root_url = "https://docs.rs/cloudevents-sdk/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/cloudevents-sdk/0.9.0")]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))] // Show feature gate in doc
 


### PR DESCRIPTION
Motivated by @FalkWoldmann's comment on #227 

Quick PR to update the `rdkafka` and `http` dependencies, as well as fix a `base64` deprecation warning.
I'm not sure about the versioning policy. The `rdkafka` minor bump doesn't cause any breaking changes for this repo, but maybe it would for downstream users?. I'm happy to keep this at `0.8.0` (since it hasn't been released yet), or maybe `0.8.1`. Let me know what you prefer, @jcrossley3 or @Lazzaretti.


Edit (2025/01/01): The tokio team released [axum version 0.8.0](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0), so I included that in this PR. 
