### PR TITLE
Release 0.8.0 bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudevents-sdk"
-version = "0.9.0"
+version = "0.8.0"
 authors = ["Francesco Guardiani <francescoguard@gmail.com>"]
 license-file = "LICENSE"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ enabling your Protocol Binding of choice:
 
 ```toml
 [dependencies]
-cloudevents-sdk = { version = "0.9.0" }
+cloudevents-sdk = { version = "0.8.0" }
 ```
 
 Now you can start creating events:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! [Extractors]: https://actix.rs/docs/extractors/
 //! [Responders]: https://actix.rs/docs/handlers/
 
-#![doc(html_root_url = "https://docs.rs/cloudevents-sdk/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/cloudevents-sdk/0.8.0")]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))] // Show feature gate in doc
 


### PR DESCRIPTION
change to 0.9.0 in a pull request was wrong, last released version is 0.7.0 -> so now preparing for release 0.8.0

`cargo test --all-features`, `cargo doc --all-features --lib` `cargo publish --dry-run` passesd